### PR TITLE
CI & Makefile: robust flags, cargo-binstall version guard, doc fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,13 @@ jobs:
       - name: Install Whitaker
         run: |
           if cargo binstall --version >/dev/null 2>&1; then
-            echo "cargo-binstall already present"
+            INSTALLED_BINSTALL_VERSION="$(cargo binstall --version | awk '{print $2}' | sed 's/^v//')"
+          else
+            INSTALLED_BINSTALL_VERSION=""
+          fi
+
+          if [ "${INSTALLED_BINSTALL_VERSION}" = "${{ env.CARGO_BINSTALL_VERSION }}" ]; then
+            echo "cargo-binstall ${INSTALLED_BINSTALL_VERSION} already present"
           else
             cargo install cargo-binstall --locked --version "${{ env.CARGO_BINSTALL_VERSION }}"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
+      CARGO_BINSTALL_VERSION: '1.15.7'
       WHITAKER_INSTALLER_VERSION: '0.2.1'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -36,12 +37,18 @@ jobs:
           key: whitaker-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WHITAKER_INSTALLER_VERSION }}
       - name: Install Whitaker
         run: |
+          if cargo binstall --version >/dev/null 2>&1; then
+            echo "cargo-binstall already present"
+          else
+            cargo install cargo-binstall --locked --version "${{ env.CARGO_BINSTALL_VERSION }}"
+          fi
+
           if command -v whitaker-installer >/dev/null 2>&1; then
             echo "whitaker-installer already present; skipping cargo binstall"
           else
             cargo binstall --no-confirm whitaker-installer@${{ env.WHITAKER_INSTALLER_VERSION }}
           fi
-          whitaker-installer
+          whitaker-installer --no-update
       - name: Lint
         run: make lint
       - name: Test and Measure Coverage

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CLIPPY_FLAGS ?= $(CARGO_FLAGS) -- $(RUST_FLAGS)
 TEST_FLAGS ?= $(CARGO_FLAGS)
 DOCTEST_FLAGS ?= --workspace --all-features
 TEST_CMD := $(if $(shell $(CARGO) nextest --version 2>/dev/null),nextest run --no-tests pass,test)
-HAS_DOCTEST_TARGETS := $(shell $(CARGO) metadata --no-deps --format-version 1 2>/dev/null | grep -q '"doctest":true' && echo 1)
+HAS_DOCTEST_TARGETS = $(shell $(CARGO) metadata --no-deps --format-version 1 2>/dev/null | grep -q '"doctest":true' && echo 1)
 MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
 

--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,18 @@ TARGET ?= repovec_appliance
 
 CARGO ?= cargo
 BUILD_JOBS ?=
+BASE_RUST_FLAGS ?= -D warnings
+BASE_RUSTDOC_FLAGS ?= -D warnings
 RUST_FLAGS ?=
-RUST_FLAGS := -D warnings $(RUST_FLAGS)
 RUSTDOC_FLAGS ?=
-RUSTDOC_FLAGS := -D warnings $(RUSTDOC_FLAGS)
+EFFECTIVE_RUST_FLAGS := $(strip $(BASE_RUST_FLAGS) $(RUST_FLAGS))
+EFFECTIVE_RUSTDOC_FLAGS := $(strip $(BASE_RUSTDOC_FLAGS) $(RUSTDOC_FLAGS))
 CARGO_FLAGS ?= --all-targets --all-features
-CLIPPY_FLAGS ?= $(CARGO_FLAGS) -- $(RUST_FLAGS)
+CLIPPY_FLAGS ?= $(CARGO_FLAGS) -- $(EFFECTIVE_RUST_FLAGS)
 TEST_FLAGS ?= $(CARGO_FLAGS)
 DOCTEST_FLAGS ?= --workspace --all-features
 TEST_CMD := $(if $(shell $(CARGO) nextest --version 2>/dev/null),nextest run --no-tests pass,test)
-HAS_DOCTEST_TARGETS = $(shell $(CARGO) metadata --no-deps --format-version 1 2>/dev/null | grep -q '"doctest":true' && echo 1)
+HAS_DOCTEST_TARGETS := $(shell $(CARGO) metadata --no-deps --format-version 1 2>/dev/null | grep -q '"doctest":true' && echo 1)
 MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
 
@@ -27,10 +29,10 @@ clean: ## Remove build artifacts
 	$(CARGO) clean
 
 test: ## Run tests with warnings treated as errors
-	RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) $(TEST_CMD) $(TEST_FLAGS) $(BUILD_JOBS)
+	RUSTFLAGS="$(EFFECTIVE_RUST_FLAGS)" $(CARGO) $(TEST_CMD) $(TEST_FLAGS) $(BUILD_JOBS)
 ifneq ($(TEST_CMD),test)
 ifneq ($(HAS_DOCTEST_TARGETS),)
-	RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) test --doc $(DOCTEST_FLAGS) $(BUILD_JOBS)
+	RUSTFLAGS="$(EFFECTIVE_RUST_FLAGS)" $(CARGO) test --doc $(DOCTEST_FLAGS) $(BUILD_JOBS)
 endif
 endif
 
@@ -38,19 +40,19 @@ target/%/$(TARGET): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(TARGET)
 
 lint: ## Run Clippy with warnings denied
-	RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --no-deps
+	RUSTDOCFLAGS="$(EFFECTIVE_RUSTDOC_FLAGS)" $(CARGO) doc --no-deps
 	$(CARGO) clippy $(CLIPPY_FLAGS)
 	$(MAKE) whitaker-lint
 
 whitaker-lint: ## Run Whitaker when available
 	@if command -v whitaker >/dev/null 2>&1; then \
-		RUSTFLAGS="$(RUST_FLAGS)" whitaker --all -- $(CARGO_FLAGS); \
+		RUSTFLAGS="$(EFFECTIVE_RUST_FLAGS)" whitaker --all -- $(CARGO_FLAGS); \
 	else \
 		echo "whitaker not found on PATH; skipping whitaker lint. Install whitaker to run this check."; \
 	fi
 
 typecheck: ## Type-check without building
-	RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) check $(CARGO_FLAGS)
+	RUSTFLAGS="$(EFFECTIVE_RUST_FLAGS)" $(CARGO) check $(CARGO_FLAGS)
 
 fmt: ## Format Rust and Markdown sources
 	$(CARGO) fmt --all

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -648,7 +648,7 @@ July 15, 2025, <https://doc.rust-lang.org/rustdoc/documentation-tests.html>
        <https://users.rust-lang.org/t/test-setup-for-doctests/50426>
 [^12]: quote_doctest - Rust - [Docs.rs](http://Docs.rs), accessed on July 15,
 2025, <https://docs.rs/quote-doctest>
-[^13]: Advanced features - The rustdoc boOK - Rust Documentation, accessed on
+[^13]: Advanced features - The rustdoc book - Rust Documentation, accessed on
        July 15, 2025, <https://doc.rust-lang.org/rustdoc/advanced-features.html>
 [^14]: Stack Overflow — Conditionally executing a module-level doctest,
 accessed on July 15, 2025,

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -622,7 +622,7 @@ accessed on July 15, 2025,
 <https://stackoverflow.com/questions/70111757/how-can-i-write-documentation-tests-for-private-modules>
 [^2]: Rustdoc doctests need fixing - Swatinem, accessed on July 15, 2025,
 <https://swatinem.de/blog/fix-rustdoc/>
-[^3]: Documentation tests - The rustdoc boOK - Rust Documentation, accessed on
+[^3]: Documentation tests - The rustdoc book - Rust Documentation, accessed on
 July 15, 2025, <https://doc.rust-lang.org/rustdoc/documentation-tests.html>
 [^4]: Documentation tests - - GitHub Pages, accessed on July 15, 2025,
 <https://ebarnard.github.io/2019-06-03-rust-smaller-trait-implementers-docs/rustdoc/documentation-tests.html>


### PR DESCRIPTION
## Summary
- Improves Makefile flag handling with BASE_RUST_FLAGS and EFFECTIVE_RUST_FLAGS
- CI: adds cargo-binstall version guard and uses whitaker-installer with --no-update
- Small documentation fix in doctest guide (book typo)

## Changes
### Build / Tooling
- Makefile: Add BASE_RUST_FLAGS, BASE_RUSTDOC_FLAGS, compute EFFECTIVE_RUST_FLAGS and EFFECTIVE_RUSTDOC_FLAGS; apply to lint, typecheck, test, and doc steps; ensure doctest target uses EFFECTIVE_RUST_FLAGS

### CI
- .github/workflows/ci.yml: Introduce CARGO_BINSTALL_VERSION env var; perform version-guarded cargo-binstall installation if not present; run whitaker-installer --no-update to avoid automatic updates

### Documentation
- docs/rust-doctest-dry-guide.md: Fix typo "boOK" to "book"

## Validation / How to test
- make fmt && make lint
- make typecheck
- make test (uses nextest if available; otherwise cargo test)

## Why these changes
- Align Makefile and CI tooling with current requirements; ensure consistent flag propagation and avoid warnings; minor doc fix

## Notes / Migration impact
- No user-facing changes

## Test plan
- [x] Lint and format pass locally
- [x] Typecheck passes
- [x] Tests run with nextest when available; fallback to cargo test

📎 **Task**: https://www.devboxer.com/task/948bf12c-489c-4d55-b927-2c4a405dadbe