### PR TITLE
Initialize multi-crate workspace with core and scaffolding binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 'on':
   push:
     branches:
-      - '**'
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 'on':
+  push:
+    branches:
+      - '**'
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
@@ -19,6 +22,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@b61ad14766ae81b830abdaf066eb3d9b6c4f537b
+      - name: Build
+        run: make build
       - name: Format
         run: make check-fmt
       - name: Markdown lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 **/*.rs.bk
+.agents/mcp/context_pack/packs/.repo.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,10 @@ project:
     ```
 
     validating formatting across the entire workspace without modifying files.
+    **Note:** This project uses nightly rustfmt to enable unstable formatting
+    options (`group_imports` and `imports_granularity` in `rustfmt.toml`).
+    The `rust-toolchain.toml` file enforces the nightly toolchain, so the
+    correct rustfmt version is automatically selected.
   - `make lint` executes:
 
     ```sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,328 @@
 version = 4
 
 [[package]]
-name = "repovec_appliance"
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "indexmap"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "repovec-core"
 version = "0.1.0"
+dependencies = [
+ "camino",
+ "rstest",
+]
+
+[[package]]
+name = "repovec-mcpd"
+version = "0.1.0"
+dependencies = [
+ "repovec-core",
+]
+
+[[package]]
+name = "repovec-tui"
+version = "0.1.0"
+dependencies = [
+ "repovec-core",
+]
+
+[[package]]
+name = "repovecd"
+version = "0.1.0"
+dependencies = [
+ "repovec-core",
+]
+
+[[package]]
+name = "repovectl"
+version = "0.1.0"
+dependencies = [
+ "repovec-core",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.10+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,74 +1,80 @@
-[package]
-name = "repovec_appliance"
+[workspace]
+members = [
+    "crates/repovec-core",
+    "crates/repovec-mcpd",
+    "crates/repovec-tui",
+    "crates/repovecd",
+    "crates/repovectl",
+]
+resolver = "3"
+
+[workspace.package]
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
+license = "ISC"
+publish = false
 
-[dependencies]
+[workspace.dependencies]
+camino = "1.1.12"
+rstest = "0.26.1"
 
-[lints.clippy]
+[workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 
-# 1. hygiene
-allow_attributes                    = "deny"
-allow_attributes_without_reason     = "deny"
-blanket_clippy_restriction_lints    = "deny"
-cognitive_complexity                = "deny"
-needless_pass_by_value              = "deny"
-implicit_hasher                     = "deny"
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
+blanket_clippy_restriction_lints = "deny"
+cognitive_complexity = "deny"
+needless_pass_by_value = "deny"
+implicit_hasher = "deny"
 
-# 2. debugging leftovers
-dbg_macro                           = "deny"
-print_stdout                        = "deny"
-print_stderr                        = "deny"
+dbg_macro = "deny"
+print_stdout = "deny"
+print_stderr = "deny"
 
-# 2. panic-prone operations
-unwrap_used                         = "deny"
-expect_used                         = "deny"
-indexing_slicing                    = "deny"
-string_slice                        = "deny"
-integer_division                    = "deny"
-integer_division_remainder_used     = "deny"
-panic_in_result_fn                  = "deny"
-unreachable                         = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+indexing_slicing = "deny"
+string_slice = "deny"
+integer_division = "deny"
+integer_division_remainder_used = "deny"
+panic_in_result_fn = "deny"
+unreachable = "deny"
 
-# 4. portability
-host_endian_bytes                   = "deny"
-little_endian_bytes                 = "deny"
-big_endian_bytes                    = "deny"
+host_endian_bytes = "deny"
+little_endian_bytes = "deny"
+big_endian_bytes = "deny"
 
-# 5. nursery idiom polish
-let_underscore_must_use             = "deny"
-or_fun_call                         = "deny"
-option_if_let_else                  = "deny"
-self_named_module_files             = "deny"
-shadow_reuse                        = "deny"
-shadow_same                         = "deny"
-shadow_unrelated                    = "deny"
-str_to_string                       = "deny"
-string_lit_as_bytes                 = "deny"
-try_err                             = "deny"
-unneeded_field_pattern              = "deny"
-use_self                            = "deny"
+let_underscore_must_use = "deny"
+or_fun_call = "deny"
+option_if_let_else = "deny"
+self_named_module_files = "deny"
+shadow_reuse = "deny"
+shadow_same = "deny"
+shadow_unrelated = "deny"
+str_to_string = "deny"
+string_lit_as_bytes = "deny"
+try_err = "deny"
+unneeded_field_pattern = "deny"
+use_self = "deny"
 
-# 6. numerical foot-guns
-float_arithmetic                    = "deny"
-cast_possible_truncation            = "deny"
-cast_possible_wrap                  = "deny"
-cast_precision_loss                 = "deny"
-lossy_float_literal                 = "deny"
+float_arithmetic = "deny"
+cast_possible_truncation = "deny"
+cast_possible_wrap = "deny"
+cast_precision_loss = "deny"
+lossy_float_literal = "deny"
 
-# 7. API ergonomics
-missing_const_for_fn                = "deny"
-must_use_candidate                  = "deny"
-unused_async                        = "deny"
+missing_const_for_fn = "deny"
+must_use_candidate = "deny"
+unused_async = "deny"
 
-# 8. Error handling
-missing_panics_doc                  = "deny"
-error_impl_error                    = "deny"
-result_large_err                    = "deny"
+missing_panics_doc = "deny"
+error_impl_error = "deny"
+result_large_err = "deny"
 
-[lints.rust]
-missing_docs                        = "deny"
+[workspace.lints.rust]
+missing_docs = "deny"
 
-[lints.rustdoc]
-missing_crate_level_docs            = "deny"
+[workspace.lints.rustdoc]
+missing_crate_level_docs = "deny"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 .PHONY: help all clean test build release lint whitaker-lint typecheck fmt check-fmt markdownlint nixie
 
 
-TARGET ?= repovec_appliance
-
 CARGO ?= cargo
 BUILD_JOBS ?=
 BASE_RUST_FLAGS ?= -D warnings
@@ -20,8 +18,11 @@ HAS_DOCTEST_TARGETS := $(shell $(CARGO) metadata --no-deps --format-version 1 2>
 MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
 
-build: target/debug/$(TARGET) ## Build debug binary
-release: target/release/$(TARGET) ## Build release binary
+build: ## Build the entire workspace in debug mode
+	$(CARGO) build --workspace $(BUILD_JOBS)
+
+release: ## Build the entire workspace in release mode
+	$(CARGO) build --workspace --release $(BUILD_JOBS)
 
 all: check-fmt lint test ## Perform a comprehensive check of code
 
@@ -35,9 +36,6 @@ ifneq ($(HAS_DOCTEST_TARGETS),)
 	RUSTFLAGS="$(EFFECTIVE_RUST_FLAGS)" $(CARGO) test --doc $(DOCTEST_FLAGS) $(BUILD_JOBS)
 endif
 endif
-
-target/%/$(TARGET): ## Build binary in debug or release mode
-	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(TARGET)
 
 lint: ## Run Clippy with warnings denied
 	RUSTDOCFLAGS="$(EFFECTIVE_RUSTDOC_FLAGS)" $(CARGO) doc --no-deps

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ endif
 endif
 
 lint: ## Run Clippy with warnings denied
-	RUSTDOCFLAGS="$(EFFECTIVE_RUSTDOC_FLAGS)" $(CARGO) doc --no-deps
-	$(CARGO) clippy $(CLIPPY_FLAGS)
+	RUSTDOCFLAGS="$(EFFECTIVE_RUSTDOC_FLAGS)" $(CARGO) doc --no-deps --workspace
+	$(CARGO) clippy --workspace $(CLIPPY_FLAGS)
 	$(MAKE) whitaker-lint
 
 whitaker-lint: ## Run Whitaker when available

--- a/crates/repovec-core/Cargo.toml
+++ b/crates/repovec-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "repovec-core"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+camino.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/repovec-core/src/lib.rs
+++ b/crates/repovec-core/src/lib.rs
@@ -1,0 +1,190 @@
+//! Shared domain types and configuration scaffolding for repovec services.
+
+use camino::Utf8PathBuf;
+
+/// Long-running processes that make up the appliance.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ServiceKind {
+    /// The repository control-plane daemon.
+    Repovecd,
+    /// The external MCP bridge daemon.
+    RepovecMcpd,
+    /// The terminal user interface.
+    RepovecTui,
+    /// The deployment and operator CLI.
+    Repovectl,
+}
+
+impl ServiceKind {
+    /// Returns the crate and binary name for the service.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use repovec_core::ServiceKind;
+    ///
+    /// assert_eq!(ServiceKind::Repovecd.binary_name(), "repovecd");
+    /// ```
+    #[must_use]
+    pub const fn binary_name(self) -> &'static str {
+        match self {
+            Self::Repovecd => "repovecd",
+            Self::RepovecMcpd => "repovec-mcpd",
+            Self::RepovecTui => "repovec-tui",
+            Self::Repovectl => "repovectl",
+        }
+    }
+}
+
+/// Canonical filesystem roots used by appliance components.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RuntimePaths {
+    config_root: Utf8PathBuf,
+    data_root: Utf8PathBuf,
+}
+
+impl RuntimePaths {
+    /// Creates a set of runtime paths from explicit config and data roots.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use camino::Utf8PathBuf;
+    /// use repovec_core::RuntimePaths;
+    ///
+    /// let paths = RuntimePaths::new(
+    ///     Utf8PathBuf::from("/etc/repovec"),
+    ///     Utf8PathBuf::from("/var/lib/repovec"),
+    /// );
+    ///
+    /// assert_eq!(paths.git_mirrors_root().as_str(), "/var/lib/repovec/git-mirrors");
+    /// ```
+    #[must_use]
+    pub const fn new(config_root: Utf8PathBuf, data_root: Utf8PathBuf) -> Self {
+        Self { config_root, data_root }
+    }
+
+    /// Returns the standard appliance runtime layout.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use repovec_core::RuntimePaths;
+    ///
+    /// let paths = RuntimePaths::appliance_defaults();
+    ///
+    /// assert_eq!(paths.config_root().as_str(), "/etc/repovec");
+    /// ```
+    #[must_use]
+    pub fn appliance_defaults() -> Self {
+        Self::new(Utf8PathBuf::from("/etc/repovec"), Utf8PathBuf::from("/var/lib/repovec"))
+    }
+
+    /// Returns the configuration directory root.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use repovec_core::RuntimePaths;
+    ///
+    /// let paths = RuntimePaths::appliance_defaults();
+    ///
+    /// assert_eq!(paths.config_root().as_str(), "/etc/repovec");
+    /// ```
+    #[must_use]
+    pub const fn config_root(&self) -> &Utf8PathBuf {
+        &self.config_root
+    }
+
+    /// Returns the mutable appliance data directory root.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use repovec_core::RuntimePaths;
+    ///
+    /// let paths = RuntimePaths::appliance_defaults();
+    ///
+    /// assert_eq!(paths.data_root().as_str(), "/var/lib/repovec");
+    /// ```
+    #[must_use]
+    pub const fn data_root(&self) -> &Utf8PathBuf {
+        &self.data_root
+    }
+
+    /// Returns the bare-mirror directory root.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use repovec_core::RuntimePaths;
+    ///
+    /// let paths = RuntimePaths::appliance_defaults();
+    ///
+    /// assert_eq!(paths.git_mirrors_root().as_str(), "/var/lib/repovec/git-mirrors");
+    /// ```
+    #[must_use]
+    pub fn git_mirrors_root(&self) -> Utf8PathBuf {
+        self.data_root.join("git-mirrors")
+    }
+
+    /// Returns the worktree directory root.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use repovec_core::RuntimePaths;
+    ///
+    /// let paths = RuntimePaths::appliance_defaults();
+    ///
+    /// assert_eq!(paths.worktrees_root().as_str(), "/var/lib/repovec/worktrees");
+    /// ```
+    #[must_use]
+    pub fn worktrees_root(&self) -> Utf8PathBuf {
+        self.data_root.join("worktrees")
+    }
+
+    /// Returns the grepai configuration directory root.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use repovec_core::RuntimePaths;
+    ///
+    /// let paths = RuntimePaths::appliance_defaults();
+    ///
+    /// assert_eq!(paths.grepai_root().as_str(), "/var/lib/repovec/.grepai");
+    /// ```
+    #[must_use]
+    pub fn grepai_root(&self) -> Utf8PathBuf {
+        self.data_root.join(".grepai")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Regression tests for the shared scaffolding surface.
+
+    use camino::Utf8PathBuf;
+    use rstest::rstest;
+
+    use super::{RuntimePaths, ServiceKind};
+
+    #[rstest]
+    fn service_binary_names_remain_stable() {
+        assert_eq!(ServiceKind::Repovecd.binary_name(), "repovecd");
+        assert_eq!(ServiceKind::RepovecMcpd.binary_name(), "repovec-mcpd");
+        assert_eq!(ServiceKind::RepovecTui.binary_name(), "repovec-tui");
+        assert_eq!(ServiceKind::Repovectl.binary_name(), "repovectl");
+    }
+
+    #[rstest]
+    fn runtime_paths_expand_from_the_data_root() {
+        let paths =
+            RuntimePaths::new(Utf8PathBuf::from("/tmp/config"), Utf8PathBuf::from("/srv/repovec"));
+
+        assert_eq!(paths.git_mirrors_root().as_str(), "/srv/repovec/git-mirrors");
+        assert_eq!(paths.worktrees_root().as_str(), "/srv/repovec/worktrees");
+        assert_eq!(paths.grepai_root().as_str(), "/srv/repovec/.grepai");
+    }
+}

--- a/crates/repovec-core/src/lib.rs
+++ b/crates/repovec-core/src/lib.rs
@@ -185,11 +185,12 @@ mod tests {
     use super::{RuntimePaths, ServiceKind};
 
     #[rstest]
-    fn service_binary_names_remain_stable() {
-        assert_eq!(ServiceKind::Repovecd.binary_name(), "repovecd");
-        assert_eq!(ServiceKind::RepovecMcpd.binary_name(), "repovec-mcpd");
-        assert_eq!(ServiceKind::RepovecTui.binary_name(), "repovec-tui");
-        assert_eq!(ServiceKind::Repovectl.binary_name(), "repovectl");
+    #[case(ServiceKind::Repovecd, "repovecd")]
+    #[case(ServiceKind::RepovecMcpd, "repovec-mcpd")]
+    #[case(ServiceKind::RepovecTui, "repovec-tui")]
+    #[case(ServiceKind::Repovectl, "repovectl")]
+    fn service_binary_names_remain_stable(#[case] kind: ServiceKind, #[case] expected: &str) {
+        assert_eq!(kind.binary_name(), expected);
     }
 
     #[rstest]

--- a/crates/repovec-core/src/lib.rs
+++ b/crates/repovec-core/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 
 /// Long-running processes that make up the appliance.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -106,8 +106,8 @@ impl RuntimePaths {
     /// assert_eq!(paths.config_root().as_str(), "/etc/repovec");
     /// ```
     #[must_use]
-    pub const fn config_root(&self) -> &Utf8PathBuf {
-        &self.config_root
+    pub fn config_root(&self) -> &Utf8Path {
+        self.config_root.as_path()
     }
 
     /// Returns the mutable appliance data directory root.
@@ -122,8 +122,8 @@ impl RuntimePaths {
     /// assert_eq!(paths.data_root().as_str(), "/var/lib/repovec");
     /// ```
     #[must_use]
-    pub const fn data_root(&self) -> &Utf8PathBuf {
-        &self.data_root
+    pub fn data_root(&self) -> &Utf8Path {
+        self.data_root.as_path()
     }
 
     /// Returns the bare-mirror directory root.

--- a/crates/repovec-core/src/lib.rs
+++ b/crates/repovec-core/src/lib.rs
@@ -1,5 +1,7 @@
 //! Shared domain types and configuration scaffolding for repovec services.
 
+use std::fmt;
+
 use camino::Utf8PathBuf;
 
 /// Long-running processes that make up the appliance.
@@ -33,6 +35,18 @@ impl ServiceKind {
             Self::RepovecTui => "repovec-tui",
             Self::Repovectl => "repovectl",
         }
+    }
+}
+
+impl fmt::Display for ServiceKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.binary_name())
+    }
+}
+
+impl AsRef<str> for ServiceKind {
+    fn as_ref(&self) -> &str {
+        self.binary_name()
     }
 }
 

--- a/crates/repovec-core/src/lib.rs
+++ b/crates/repovec-core/src/lib.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use camino::{Utf8Path, Utf8PathBuf};
 
-/// Long-running processes that make up the appliance.
+/// Service types: daemons (`Repovecd`, `RepovecMcpd`), terminal UI (`RepovecTui`), and CLI (`Repovectl`).
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ServiceKind {
     /// The repository control-plane daemon.
@@ -110,7 +110,7 @@ impl RuntimePaths {
         self.config_root.as_path()
     }
 
-    /// Returns the mutable appliance data directory root.
+    /// Returns an immutable borrowed path to the appliance data directory root.
     ///
     /// # Examples
     ///
@@ -126,6 +126,12 @@ impl RuntimePaths {
         self.data_root.as_path()
     }
 
+    /// Private helper for constructing data subdirectory paths.
+    #[inline]
+    fn data_child(&self, name: &str) -> Utf8PathBuf {
+        self.data_root.join(name)
+    }
+
     /// Returns the bare-mirror directory root.
     ///
     /// # Examples
@@ -139,7 +145,7 @@ impl RuntimePaths {
     /// ```
     #[must_use]
     pub fn git_mirrors_root(&self) -> Utf8PathBuf {
-        self.data_root.join("git-mirrors")
+        self.data_child("git-mirrors")
     }
 
     /// Returns the worktree directory root.
@@ -155,7 +161,7 @@ impl RuntimePaths {
     /// ```
     #[must_use]
     pub fn worktrees_root(&self) -> Utf8PathBuf {
-        self.data_root.join("worktrees")
+        self.data_child("worktrees")
     }
 
     /// Returns the grepai data directory root.
@@ -174,7 +180,7 @@ impl RuntimePaths {
     /// ```
     #[must_use]
     pub fn grepai_root(&self) -> Utf8PathBuf {
-        self.data_root.join(".grepai")
+        self.data_child(".grepai")
     }
 }
 

--- a/crates/repovec-core/src/lib.rs
+++ b/crates/repovec-core/src/lib.rs
@@ -158,7 +158,10 @@ impl RuntimePaths {
         self.data_root.join("worktrees")
     }
 
-    /// Returns the grepai configuration directory root.
+    /// Returns the grepai data directory root.
+    ///
+    /// Note: grepai configuration is stored under the data root rather than the
+    /// configuration root, as it contains both configuration and mutable index data.
     ///
     /// # Examples
     ///
@@ -193,7 +196,7 @@ mod tests {
         assert_eq!(kind.binary_name(), expected);
     }
 
-    #[rstest]
+    #[test]
     fn runtime_paths_expand_from_the_data_root() {
         let paths =
             RuntimePaths::new(Utf8PathBuf::from("/tmp/config"), Utf8PathBuf::from("/srv/repovec"));

--- a/crates/repovec-mcpd/Cargo.toml
+++ b/crates/repovec-mcpd/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "repovec-mcpd"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+repovec-core = { path = "../repovec-core" }
+
+[lints]
+workspace = true

--- a/crates/repovec-mcpd/src/main.rs
+++ b/crates/repovec-mcpd/src/main.rs
@@ -1,0 +1,5 @@
+//! Process entry point for the repovec MCP bridge daemon.
+
+fn main() {
+    let _arguments = std::env::args_os();
+}

--- a/crates/repovec-tui/Cargo.toml
+++ b/crates/repovec-tui/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "repovec-tui"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+repovec-core = { path = "../repovec-core" }
+
+[lints]
+workspace = true

--- a/crates/repovec-tui/src/main.rs
+++ b/crates/repovec-tui/src/main.rs
@@ -1,0 +1,5 @@
+//! Process entry point for the repovec terminal user interface.
+
+fn main() {
+    let _arguments = std::env::args_os();
+}

--- a/crates/repovecd/Cargo.toml
+++ b/crates/repovecd/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "repovecd"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+repovec-core = { path = "../repovec-core" }
+
+[lints]
+workspace = true

--- a/crates/repovecd/src/main.rs
+++ b/crates/repovecd/src/main.rs
@@ -1,0 +1,5 @@
+//! Process entry point for the repovec control-plane daemon.
+
+fn main() {
+    let _arguments = std::env::args_os();
+}

--- a/crates/repovectl/Cargo.toml
+++ b/crates/repovectl/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "repovectl"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+repovec-core = { path = "../repovec-core" }
+
+[lints]
+workspace = true

--- a/crates/repovectl/src/main.rs
+++ b/crates/repovectl/src/main.rs
@@ -1,0 +1,5 @@
+//! Process entry point for the repovec operator CLI.
+
+fn main() {
+    let _arguments = std::env::args_os();
+}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,5 @@
 edition = "2024"
+unstable_features = true
 group_imports = "StdExternalCrate"
 imports_granularity = "Module"
 newline_style = "Unix"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+edition = "2024"
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+newline_style = "Unix"
+use_small_heuristics = "Max"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,0 @@
-//! `Repovec Appliance` application entry point.
-
-// TODO: Remove this stub and implement actual application functionality.
-/// Application entry point.
-#[expect(clippy::print_stdout, reason = "CLI output is the intended behaviour")]
-fn main() {
-    println!("Hello from Repovec Appliance!");
-}


### PR DESCRIPTION
## Summary
- Establishes a Rust workspace (monorepo) with five crates: repovec-core, repovec-mcpd, repovec-tui, repovecd, repovectl
- Adds shared core domain types (ServiceKind, RuntimePaths) in repovec-core
- Adds per-crate binaries as simple entry points for future service implementations
- Updates CI and Makefile to build the full workspace
- Removes the old root main.rs in favor of per-crate binaries
- Adds rustfmt.toml for consistent formatting

## Changes
### Project structure
- Top-level Cargo.toml now defines a workspace with the five crates
- Added rustfmt.toml for consistent formatting
- Deleted old root src/main.rs

### Core crate
- New crate repovec-core with workspace-based versioning and dependencies
- Exposes ServiceKind and RuntimePaths with basic methods
- Includes tests for core scaffolding (binary names and path expansion)

### Additional crates (scaffolding)
- New crates with minimal entry points:
  - crates/repovec-mcpd, crates/repovec-tui, crates/repovecd, crates/repovectl
- Each has a simple main() that parses args (placeholder)

### CI and tooling
- CI workflow updated to build the workspace
- Makefile updated to build the entire workspace with cargo --workspace
- rustfmt.toml added for formatting rules

### Miscellaneous
- Updated .gitignore and Cargo.lock accordingly
- Removed old root main.rs in favor of per-crate binaries

## Why this change
- Lays groundwork for a scalable multi-crate project with a shared core and service binaries

## How to test
- cargo build --workspace
- cargo test --workspace
- cargo fmt --all
- Ensure CI runs workspace builds

## Notes / compatibility
- Old root main.rs removed; external tooling should target new crates
- Crates are scaffolding placeholders for future logic

## Task references
- Task: https://www.devboxer.com/task/93baea7c-d88c-4897-a4ad-578ec143682e
- Task: https://www.devboxer.com/task/7b6e41ae-2bd1-4cfd-9f4f-dcf0f25c70c6e