### PR TITLE
Serialize qdrant key provisioning (#29)

### DIFF
--- a/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
+++ b/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
@@ -5,6 +5,7 @@
 //! `QDRANT_API_KEY_ENVIRONMENT_VARIABLE`, and the packaging assets under
 //! `packaging/`.
 
+use insta::assert_snapshot;
 use proptest::prelude::*;
 
 use super::{QDRANT_API_KEY_ENVIRONMENT_VARIABLE, QDRANT_API_KEY_SECRET, QDRANT_API_KEY_SERVICE};
@@ -47,6 +48,16 @@ fn helper_offset_after(needle: &str, offset: usize) -> usize {
         );
     };
     offset + relative_offset
+}
+
+fn helper_slice(start: usize, end: usize) -> &'static str {
+    let Some(slice) = PROVISIONING_HELPER.get(start..end) else {
+        panic!(
+            "helper slice should use valid byte boundaries: start={start}, end={end}, helper_len={}",
+            PROVISIONING_HELPER.len()
+        );
+    };
+    slice
 }
 
 const PROVISIONING_SERVICE: &str =
@@ -194,6 +205,35 @@ fn provisioning_helper_does_not_commit_or_echo_a_raw_key_literal() {
     assert!(PROVISIONING_HELPER.contains("/dev/urandom"));
 }
 
+#[test]
+fn provisioning_helper_defines_required_functions_with_correct_implementations() {
+    assert!(PROVISIONING_HELPER.contains("release_lock()"));
+    assert!(
+        PROVISIONING_HELPER.contains("flock -u 9"),
+        "release_lock must call flock -u 9 and must not be a no-op"
+    );
+    assert!(PROVISIONING_HELPER.contains("debug_log()"));
+    assert!(PROVISIONING_HELPER.contains("REPOVEC_DEBUG:-}\" = \"1\""));
+    assert!(PROVISIONING_HELPER.contains("generate_key_file()"));
+
+    let flock_pos = helper_offset("flock 9");
+    let trap_sites: Vec<usize> = PROVISIONING_HELPER
+        .match_indices("trap '")
+        .map(|(i, _)| i)
+        .filter(|&i| i > flock_pos)
+        .collect();
+    assert!(!trap_sites.is_empty(), "expected trap handlers after flock");
+    for pos in trap_sites {
+        let suffix = helper_slice(pos, PROVISIONING_HELPER.len());
+        let line_end = suffix.find('\n').map_or(PROVISIONING_HELPER.len(), |n| pos + n);
+        let trap_line = helper_slice(pos, line_end);
+        assert!(
+            trap_line.contains("release_lock"),
+            "trap handler must include release_lock: {trap_line:?}",
+        );
+    }
+}
+
 /// Collects all byte offsets of `needle` in `PROVISIONING_HELPER`.
 fn all_helper_offsets(needle: &str) -> Vec<usize> {
     PROVISIONING_HELPER.match_indices(needle).map(|(i, _)| i).collect()
@@ -239,26 +279,23 @@ fn key_generation_call_site_is_inside_locked_critical_section() {
     );
 }
 
-proptest! {
-    /// `flock 9` precedes every mutable operation in the helper, regardless of
-    /// which operation is selected.
-    #[test]
-    fn flock_precedes_every_mutable_operation(
-        op_pos in proptest::sample::select(vec![
-            helper_offset("podman secret inspect \"${SECRET_NAME}\""),
-            helper_offset("podman secret rm \"${SECRET_NAME}\""),
-            helper_offset("podman secret create \"${SECRET_NAME}\""),
+#[test]
+fn flock_precedes_every_mutable_operation() {
+    let flock_pos = helper_offset("flock 9");
+    let mutable_ops = [
+        ("podman secret inspect", helper_offset("podman secret inspect \"${SECRET_NAME}\"")),
+        ("podman secret rm", helper_offset("podman secret rm \"${SECRET_NAME}\"")),
+        ("podman secret create", helper_offset("podman secret create \"${SECRET_NAME}\"")),
+        (
+            "generate_key_file",
             helper_offset_after(
                 "generate_key_file",
-                helper_offset("if [ ! -e \"${KEY_FILE}\" ]; then")
+                helper_offset("if [ ! -e \"${KEY_FILE}\" ]; then"),
             ),
-        ]),
-    ) {
-        let flock_pos = helper_offset("flock 9");
-        prop_assert!(
-            flock_pos < op_pos,
-            "flock at {flock_pos} must precede mutable operation at {op_pos}",
-        );
+        ),
+    ];
+    for (name, op_pos) in mutable_ops {
+        assert!(flock_pos < op_pos, "flock at {flock_pos} must precede {name} at {op_pos}");
     }
 }
 
@@ -272,4 +309,33 @@ fn fail_closed_path_logs_error_and_exits_non_zero() {
 
     assert!(else_branch < failure_log, "fail-closed else branch must precede its error log");
     assert!(failure_log < failure_exit, "error log must precede exit 1 on the fail-closed path");
+}
+
+#[test]
+fn provisioning_helper_lock_critical_section_snapshot() {
+    // Capture the text from the `exec 9>` line through the first
+    // `release_lock` call so the snapshot encodes the lock-acquisition
+    // protocol and the bootstrap order.
+    let start = helper_offset("exec 9>\"${LOCK_FILE}\"");
+    let first_release = helper_offset_after("release_lock", helper_offset("flock 9"));
+    let end = first_release + "release_lock".len();
+    assert_snapshot!("lock_critical_section", helper_slice(start, end));
+}
+
+#[test]
+fn provisioning_helper_fail_closed_branch_snapshot() {
+    // Capture the unexpected-removal else-branch so the snapshot encodes
+    // fail-closed semantics.
+    let start = helper_offset("else\n            # Fail closed:");
+    let end = helper_offset_after("exit 1", start) + "exit 1".len();
+    assert_snapshot!("fail_closed_else_branch", helper_slice(start, end));
+}
+
+#[test]
+fn provisioning_helper_release_lock_implementation_snapshot() {
+    // Snapshot the release_lock() function body so a no-op replacement
+    // causes an immediate snapshot failure.
+    let start = helper_offset("release_lock()");
+    let end = helper_offset_after("\n}", start) + "\n}".len();
+    assert_snapshot!("release_lock_implementation", helper_slice(start, end));
 }

--- a/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
+++ b/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
@@ -92,8 +92,18 @@ fn provisioning_helper_removes_stale_secret_before_generating_key_file() {
 }
 
 #[test]
-fn provisioning_helper_uses_flock_for_mutual_exclusion() {
-    let lock_file = helper_offset!("/var/lock/repovec-qdrant-api-key.lock");
+fn provisioning_helper_uses_a_root_controlled_lock_path() {
+    let lock_file = helper_offset!("/etc/repovec/repovec-qdrant-api-key.lock");
+    let flock = helper_offset!("flock 9");
+
+    assert!(PROVISIONING_HELPER.contains("debug_log \"acquired ${LOCK_FILE}\""));
+    assert!(PROVISIONING_HELPER.contains("debug_log \"released ${LOCK_FILE}\""));
+    assert!(!PROVISIONING_HELPER.contains("LOCK_FILE=/var/lock/"));
+    assert!(lock_file < flock);
+}
+
+#[test]
+fn provisioning_helper_serializes_secret_and_key_operations() {
     let flock = helper_offset!("flock 9");
     let secret_inspection = helper_offset!("podman secret inspect \"${SECRET_NAME}\"");
     let secret_removal = helper_offset!("podman secret rm \"${SECRET_NAME}\"");
@@ -102,9 +112,6 @@ fn provisioning_helper_uses_flock_for_mutual_exclusion() {
     let secret_creation = helper_offset!("podman secret create \"${SECRET_NAME}\"");
 
     assert!(PROVISIONING_HELPER.contains("od -An -N32 -tx1"));
-    assert!(PROVISIONING_HELPER.contains("debug_log \"acquired ${LOCK_FILE}\""));
-    assert!(PROVISIONING_HELPER.contains("debug_log \"released ${LOCK_FILE}\""));
-    assert!(lock_file < flock);
     assert!(flock < secret_inspection);
     assert!(flock < secret_removal);
     assert!(flock < key_generation);

--- a/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
+++ b/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
@@ -19,9 +19,13 @@ macro_rules! include_packaging_asset {
 /// `PROVISIONING_HELPER`, panicking if the needle is missing.
 fn helper_offset(needle: &str) -> usize {
     let Some(offset) = PROVISIONING_HELPER.find(needle) else {
-        panic!("helper should contain expected text");
+        panic!("helper should contain expected text: {needle:?}");
     };
     offset
+}
+
+fn helper_suffix_preview(suffix: &str) -> String {
+    if suffix.len() <= 120 { suffix.to_owned() } else { suffix.chars().take(120).collect() }
 }
 
 /// Returns the byte offset of the first occurrence of `needle` in
@@ -30,10 +34,17 @@ fn helper_offset(needle: &str) -> usize {
 /// occurrence exists after `offset`.
 fn helper_offset_after(needle: &str, offset: usize) -> usize {
     let Some(suffix) = PROVISIONING_HELPER.get(offset..) else {
-        panic!("helper offset should be a valid byte boundary");
+        panic!(
+            "helper offset should be a valid byte boundary: offset={offset}, helper_len={}",
+            PROVISIONING_HELPER.len()
+        );
     };
     let Some(relative_offset) = suffix.find(needle) else {
-        panic!("helper should contain expected text after offset");
+        let suffix_preview = helper_suffix_preview(suffix);
+        panic!(
+            "helper should contain expected text after offset: needle={needle:?}, \
+             offset={offset}, suffix_preview={suffix_preview:?}"
+        );
     };
     offset + relative_offset
 }
@@ -215,23 +226,17 @@ proptest! {
     }
 }
 
-proptest! {
-    /// Early `exit 1` paths appear before `flock 9`, while the key-generation
-    /// call site remains inside the locked critical section.
-    #[test]
-    fn early_exits_do_not_acquire_lock(
-        exit_pos in proptest::sample::select(all_helper_offsets("exit 1")),
-    ) {
-        let flock_pos = helper_offset("flock 9");
-        let missing_key_branch = helper_offset("if [ ! -e \"${KEY_FILE}\" ]; then");
-        let key_generation = helper_offset_after("generate_key_file", missing_key_branch);
-        prop_assume!(exit_pos < flock_pos);
+/// Key generation is invoked only from the locked main-flow critical section.
+#[test]
+fn key_generation_call_site_is_inside_locked_critical_section() {
+    let flock_pos = helper_offset("flock 9");
+    let missing_key_branch = helper_offset("if [ ! -e \"${KEY_FILE}\" ]; then");
+    let key_generation = helper_offset_after("generate_key_file", missing_key_branch);
 
-        prop_assert!(
-            flock_pos < key_generation,
-            "flock at {flock_pos} must precede key generation at {key_generation}",
-        );
-    }
+    assert!(
+        flock_pos < key_generation,
+        "flock at {flock_pos} must precede key generation at {key_generation}",
+    );
 }
 
 proptest! {

--- a/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
+++ b/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
@@ -17,25 +17,25 @@ macro_rules! include_packaging_asset {
 
 /// Returns the byte offset of the first occurrence of `needle` in
 /// `PROVISIONING_HELPER`, panicking if the needle is missing.
-macro_rules! helper_offset {
-    ($needle:expr) => {
-        PROVISIONING_HELPER.find($needle).expect("helper should contain expected text")
+fn helper_offset(needle: &str) -> usize {
+    let Some(offset) = PROVISIONING_HELPER.find(needle) else {
+        panic!("helper should contain expected text");
     };
+    offset
 }
 
 /// Returns the byte offset of the first occurrence of `needle` in
 /// `PROVISIONING_HELPER` after `offset`, useful for ordering assertions.
 /// Panics if `offset` is not a valid UTF-8 boundary or if no matching
 /// occurrence exists after `offset`.
-macro_rules! helper_offset_after {
-    ($needle:expr, $offset:expr) => {
-        $offset
-            + PROVISIONING_HELPER
-                .get($offset..)
-                .expect("helper offset should be a valid byte boundary")
-                .find($needle)
-                .expect("helper should contain expected text after offset")
+fn helper_offset_after(needle: &str, offset: usize) -> usize {
+    let Some(suffix) = PROVISIONING_HELPER.get(offset..) else {
+        panic!("helper offset should be a valid byte boundary");
     };
+    let Some(relative_offset) = suffix.find(needle) else {
+        panic!("helper should contain expected text after offset");
+    };
+    offset + relative_offset
 }
 
 const PROVISIONING_SERVICE: &str =
@@ -73,12 +73,12 @@ fn provisioning_helper_uses_the_canonical_secret_contract() {
 
 #[test]
 fn provisioning_helper_fails_closed_on_unexpected_secret_removal_errors() {
-    let removal = helper_offset!("podman secret rm \"${SECRET_NAME}\"");
-    let in_use_check = helper_offset!("grep -qi 'in use' \"${rm_error}\"");
-    let in_use_exit = helper_offset!("log \"podman secret is in use; leaving existing secret");
-    let unexpected_branch = helper_offset!("else\n            # Fail closed:");
-    let unexpected_log = helper_offset!("log \"podman secret removal failed: $(cat");
-    let unexpected_exit = helper_offset_after!("exit 1", unexpected_log);
+    let removal = helper_offset("podman secret rm \"${SECRET_NAME}\"");
+    let in_use_check = helper_offset("grep -qi 'in use' \"${rm_error}\"");
+    let in_use_exit = helper_offset("log \"podman secret is in use; leaving existing secret");
+    let unexpected_branch = helper_offset("else\n            # Fail closed:");
+    let unexpected_log = helper_offset("log \"podman secret removal failed: $(cat");
+    let unexpected_exit = helper_offset_after("exit 1", unexpected_log);
 
     assert!(removal < in_use_check);
     assert!(in_use_check < in_use_exit);
@@ -101,10 +101,10 @@ fn provisioning_helper_removes_stale_secret_before_generating_key_file() {
 
 #[test]
 fn provisioning_helper_uses_a_root_controlled_lock_path() {
-    let lock_file = helper_offset!("/etc/repovec/repovec-qdrant-api-key.lock");
-    let flock = helper_offset!("flock 9");
-    let debug_waiting = helper_offset!("debug_log \"waiting for ${LOCK_FILE}\"");
-    let debug_acquired = helper_offset!("debug_log \"acquired ${LOCK_FILE}\"");
+    let lock_file = helper_offset("/etc/repovec/repovec-qdrant-api-key.lock");
+    let flock = helper_offset("flock 9");
+    let debug_waiting = helper_offset("debug_log \"waiting for ${LOCK_FILE}\"");
+    let debug_acquired = helper_offset("debug_log \"acquired ${LOCK_FILE}\"");
 
     assert!(PROVISIONING_HELPER.contains("debug_log \"acquired ${LOCK_FILE}\""));
     assert!(PROVISIONING_HELPER.contains("debug_log \"released ${LOCK_FILE}\""));
@@ -116,12 +116,12 @@ fn provisioning_helper_uses_a_root_controlled_lock_path() {
 
 #[test]
 fn provisioning_helper_serializes_secret_and_key_operations() {
-    let flock = helper_offset!("flock 9");
-    let secret_inspection = helper_offset!("podman secret inspect \"${SECRET_NAME}\"");
-    let secret_removal = helper_offset!("podman secret rm \"${SECRET_NAME}\"");
-    let missing_key_branch = helper_offset!("if [ ! -e \"${KEY_FILE}\" ]; then");
-    let key_generation = helper_offset_after!("generate_key_file", missing_key_branch);
-    let secret_creation = helper_offset!("podman secret create \"${SECRET_NAME}\"");
+    let flock = helper_offset("flock 9");
+    let secret_inspection = helper_offset("podman secret inspect \"${SECRET_NAME}\"");
+    let secret_removal = helper_offset("podman secret rm \"${SECRET_NAME}\"");
+    let missing_key_branch = helper_offset("if [ ! -e \"${KEY_FILE}\" ]; then");
+    let key_generation = helper_offset_after("generate_key_file", missing_key_branch);
+    let secret_creation = helper_offset("podman secret create \"${SECRET_NAME}\"");
 
     assert!(PROVISIONING_HELPER.contains("od -An -N32 -tx1"));
     assert!(flock < secret_inspection);
@@ -154,24 +154,24 @@ fn provisioning_helper_preserves_existing_keys_and_locks_permissions() {
 
 #[test]
 fn provisioning_helper_releases_lock_before_every_error_exit() {
-    let release_lock_a = helper_offset!("release_lock");
-    let exit_a = helper_offset_after!("exit 1", release_lock_a);
+    let release_lock_a = helper_offset("release_lock");
+    let exit_a = helper_offset_after("exit 1", release_lock_a);
     assert!(release_lock_a < exit_a);
 
-    let release_lock_b = helper_offset_after!("release_lock", exit_a);
-    let exit_b = helper_offset_after!("exit 0", release_lock_b);
+    let release_lock_b = helper_offset_after("release_lock", exit_a);
+    let exit_b = helper_offset_after("exit 0", release_lock_b);
     assert!(release_lock_b < exit_b);
 
-    let release_lock_c = helper_offset_after!("release_lock", exit_b);
-    let exit_c = helper_offset_after!("exit 1", release_lock_c);
+    let release_lock_c = helper_offset_after("release_lock", exit_b);
+    let exit_c = helper_offset_after("exit 1", release_lock_c);
     assert!(release_lock_c < exit_c);
 
-    let release_lock_d = helper_offset_after!("release_lock", exit_c);
-    let exit_d = helper_offset_after!("exit 1", release_lock_d);
+    let release_lock_d = helper_offset_after("release_lock", exit_c);
+    let exit_d = helper_offset_after("exit 1", release_lock_d);
     assert!(release_lock_d < exit_d);
 
-    let created_log = helper_offset!("created qdrant API-key podman secret");
-    let release_lock_e = helper_offset_after!("release_lock", created_log);
+    let created_log = helper_offset("created qdrant API-key podman secret");
+    let release_lock_e = helper_offset_after("release_lock", created_log);
     assert!(created_log < release_lock_e);
 }
 
@@ -189,40 +189,47 @@ fn all_helper_offsets(needle: &str) -> Vec<usize> {
 }
 
 proptest! {
-    /// Every `exit 1` in the helper is preceded by an explicit `release_lock`
-    /// call that itself follows the `flock 9` acquisition, regardless of which
-    /// error path is taken.
+    /// Every critical-section `exit 1` is preceded by a `release_lock` call
+    /// that follows the `flock 9` acquisition.
     #[test]
-    fn every_error_exit_1_is_preceded_by_release_lock(
+    fn critical_section_exits_release_lock_before_exit_1(
         exit_pos in proptest::sample::select(all_helper_offsets("exit 1")),
     ) {
-        let flock_pos = helper_offset!("flock 9");
-        let missing_key_branch = helper_offset!("if [ ! -e \"${KEY_FILE}\" ]; then");
-        let key_generation = helper_offset_after!("generate_key_file", missing_key_branch);
+        let flock_pos = helper_offset("flock 9");
+        prop_assume!(exit_pos > flock_pos);
+
         let prefix = PROVISIONING_HELPER
             .get(..exit_pos)
             .expect("exit_pos must be a valid byte boundary");
         let release_pos = prefix
             .rfind("release_lock")
             .expect("every exit 1 must be preceded by release_lock");
-        if release_pos < flock_pos {
-            prop_assert!(
-                exit_pos < flock_pos,
-                "function-local exit 1 at {exit_pos} must appear before flock at {flock_pos}",
-            );
-            prop_assert!(
-                flock_pos < key_generation,
-                "flock at {flock_pos} must precede key generation at {key_generation}",
-            );
-        } else {
-            prop_assert!(
-                flock_pos < release_pos,
-                "release_lock at {release_pos} must follow flock at {flock_pos}",
-            );
-        }
+        prop_assert!(
+            flock_pos < release_pos,
+            "release_lock at {release_pos} must follow flock at {flock_pos}",
+        );
         prop_assert!(
             release_pos < exit_pos,
             "release_lock at {release_pos} must precede exit 1 at {exit_pos}",
+        );
+    }
+}
+
+proptest! {
+    /// Early `exit 1` paths appear before `flock 9`, while the key-generation
+    /// call site remains inside the locked critical section.
+    #[test]
+    fn early_exits_do_not_acquire_lock(
+        exit_pos in proptest::sample::select(all_helper_offsets("exit 1")),
+    ) {
+        let flock_pos = helper_offset("flock 9");
+        let missing_key_branch = helper_offset("if [ ! -e \"${KEY_FILE}\" ]; then");
+        let key_generation = helper_offset_after("generate_key_file", missing_key_branch);
+        prop_assume!(exit_pos < flock_pos);
+
+        prop_assert!(
+            flock_pos < key_generation,
+            "flock at {flock_pos} must precede key generation at {key_generation}",
         );
     }
 }
@@ -233,16 +240,16 @@ proptest! {
     #[test]
     fn flock_precedes_every_mutable_operation(
         op_pos in proptest::sample::select(vec![
-            helper_offset!("podman secret inspect \"${SECRET_NAME}\""),
-            helper_offset!("podman secret rm \"${SECRET_NAME}\""),
-            helper_offset!("podman secret create \"${SECRET_NAME}\""),
-            helper_offset_after!(
+            helper_offset("podman secret inspect \"${SECRET_NAME}\""),
+            helper_offset("podman secret rm \"${SECRET_NAME}\""),
+            helper_offset("podman secret create \"${SECRET_NAME}\""),
+            helper_offset_after(
                 "generate_key_file",
-                helper_offset!("if [ ! -e \"${KEY_FILE}\" ]; then")
+                helper_offset("if [ ! -e \"${KEY_FILE}\" ]; then")
             ),
         ]),
     ) {
-        let flock_pos = helper_offset!("flock 9");
+        let flock_pos = helper_offset("flock 9");
         prop_assert!(
             flock_pos < op_pos,
             "flock at {flock_pos} must precede mutable operation at {op_pos}",
@@ -250,35 +257,14 @@ proptest! {
     }
 }
 
-proptest! {
-    /// The fail-closed invariant holds for every combination of
-    /// `secret_exists x key_file_exists`: the unexpected-removal else-branch
-    /// always progresses to an error log followed by `exit 1`, with no path
-    /// that falls through silently.
-    #[test]
-    fn fail_closed_semantics_hold_for_all_secret_and_key_file_states(
-        secret_exists in any::<bool>(),
-        key_file_exists in any::<bool>(),
-    ) {
-        // The helper is a static string; runtime state does not change it.
-        // These parameters document the full state space over which the
-        // invariant is claimed to hold.
-        let _ = (secret_exists, key_file_exists);
+/// The unexpected-removal else-branch logs an error and exits non-zero instead
+/// of falling through silently.
+#[test]
+fn fail_closed_path_logs_error_and_exits_non_zero() {
+    let else_branch = helper_offset("else\n            # Fail closed:");
+    let failure_log = helper_offset_after("log \"podman secret removal failed:", else_branch);
+    let failure_exit = helper_offset_after("exit 1", failure_log);
 
-        let else_branch = helper_offset!("else\n            # Fail closed:");
-        let failure_log = helper_offset_after!(
-            "log \"podman secret removal failed:",
-            else_branch
-        );
-        let failure_exit = helper_offset_after!("exit 1", failure_log);
-
-        prop_assert!(
-            else_branch < failure_log,
-            "fail-closed else branch must precede its error log",
-        );
-        prop_assert!(
-            failure_log < failure_exit,
-            "error log must precede exit 1 on the fail-closed path",
-        );
-    }
+    assert!(else_branch < failure_log, "fail-closed else branch must precede its error log");
+    assert!(failure_log < failure_exit, "error log must precede exit 1 on the fail-closed path");
 }

--- a/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
+++ b/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
@@ -5,6 +5,8 @@
 //! `QDRANT_API_KEY_ENVIRONMENT_VARIABLE`, and the packaging assets under
 //! `packaging/`.
 
+use proptest::prelude::*;
+
 use super::{QDRANT_API_KEY_ENVIRONMENT_VARIABLE, QDRANT_API_KEY_SECRET, QDRANT_API_KEY_SERVICE};
 
 macro_rules! include_packaging_asset {
@@ -179,4 +181,104 @@ fn provisioning_helper_does_not_commit_or_echo_a_raw_key_literal() {
     assert!(!PROVISIONING_HELPER.contains("echo \"${KEY_FILE}\""));
     assert!(!PROVISIONING_HELPER.contains("echo \"${tmp_file}\""));
     assert!(PROVISIONING_HELPER.contains("/dev/urandom"));
+}
+
+/// Collects all byte offsets of `needle` in `PROVISIONING_HELPER`.
+fn all_helper_offsets(needle: &str) -> Vec<usize> {
+    PROVISIONING_HELPER.match_indices(needle).map(|(i, _)| i).collect()
+}
+
+proptest! {
+    /// Every `exit 1` in the helper is preceded by an explicit `release_lock`
+    /// call that itself follows the `flock 9` acquisition, regardless of which
+    /// error path is taken.
+    #[test]
+    fn every_error_exit_1_is_preceded_by_release_lock(
+        exit_pos in proptest::sample::select(all_helper_offsets("exit 1")),
+    ) {
+        let flock_pos = helper_offset!("flock 9");
+        let missing_key_branch = helper_offset!("if [ ! -e \"${KEY_FILE}\" ]; then");
+        let key_generation = helper_offset_after!("generate_key_file", missing_key_branch);
+        let prefix = PROVISIONING_HELPER
+            .get(..exit_pos)
+            .expect("exit_pos must be a valid byte boundary");
+        let release_pos = prefix
+            .rfind("release_lock")
+            .expect("every exit 1 must be preceded by release_lock");
+        if release_pos < flock_pos {
+            prop_assert!(
+                exit_pos < flock_pos,
+                "function-local exit 1 at {exit_pos} must appear before flock at {flock_pos}",
+            );
+            prop_assert!(
+                flock_pos < key_generation,
+                "flock at {flock_pos} must precede key generation at {key_generation}",
+            );
+        } else {
+            prop_assert!(
+                flock_pos < release_pos,
+                "release_lock at {release_pos} must follow flock at {flock_pos}",
+            );
+        }
+        prop_assert!(
+            release_pos < exit_pos,
+            "release_lock at {release_pos} must precede exit 1 at {exit_pos}",
+        );
+    }
+}
+
+proptest! {
+    /// `flock 9` precedes every mutable operation in the helper, regardless of
+    /// which operation is selected.
+    #[test]
+    fn flock_precedes_every_mutable_operation(
+        op_pos in proptest::sample::select(vec![
+            helper_offset!("podman secret inspect \"${SECRET_NAME}\""),
+            helper_offset!("podman secret rm \"${SECRET_NAME}\""),
+            helper_offset!("podman secret create \"${SECRET_NAME}\""),
+            helper_offset_after!(
+                "generate_key_file",
+                helper_offset!("if [ ! -e \"${KEY_FILE}\" ]; then")
+            ),
+        ]),
+    ) {
+        let flock_pos = helper_offset!("flock 9");
+        prop_assert!(
+            flock_pos < op_pos,
+            "flock at {flock_pos} must precede mutable operation at {op_pos}",
+        );
+    }
+}
+
+proptest! {
+    /// The fail-closed invariant holds for every combination of
+    /// `secret_exists x key_file_exists`: the unexpected-removal else-branch
+    /// always progresses to an error log followed by `exit 1`, with no path
+    /// that falls through silently.
+    #[test]
+    fn fail_closed_semantics_hold_for_all_secret_and_key_file_states(
+        secret_exists in any::<bool>(),
+        key_file_exists in any::<bool>(),
+    ) {
+        // The helper is a static string; runtime state does not change it.
+        // These parameters document the full state space over which the
+        // invariant is claimed to hold.
+        let _ = (secret_exists, key_file_exists);
+
+        let else_branch = helper_offset!("else\n            # Fail closed:");
+        let failure_log = helper_offset_after!(
+            "log \"podman secret removal failed:",
+            else_branch
+        );
+        let failure_exit = helper_offset_after!("exit 1", failure_log);
+
+        prop_assert!(
+            else_branch < failure_log,
+            "fail-closed else branch must precede its error log",
+        );
+        prop_assert!(
+            failure_log < failure_exit,
+            "error log must precede exit 1 on the fail-closed path",
+        );
+    }
 }

--- a/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
+++ b/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
@@ -151,6 +151,29 @@ fn provisioning_helper_preserves_existing_keys_and_locks_permissions() {
 }
 
 #[test]
+fn provisioning_helper_releases_lock_before_every_error_exit() {
+    let release_lock_a = helper_offset!("release_lock");
+    let exit_a = helper_offset_after!("exit 1", release_lock_a);
+    assert!(release_lock_a < exit_a);
+
+    let release_lock_b = helper_offset_after!("release_lock", exit_a);
+    let exit_b = helper_offset_after!("exit 0", release_lock_b);
+    assert!(release_lock_b < exit_b);
+
+    let release_lock_c = helper_offset_after!("release_lock", exit_b);
+    let exit_c = helper_offset_after!("exit 1", release_lock_c);
+    assert!(release_lock_c < exit_c);
+
+    let release_lock_d = helper_offset_after!("release_lock", exit_c);
+    let exit_d = helper_offset_after!("exit 1", release_lock_d);
+    assert!(release_lock_d < exit_d);
+
+    let created_log = helper_offset!("created qdrant API-key podman secret");
+    let release_lock_e = helper_offset_after!("release_lock", created_log);
+    assert!(created_log < release_lock_e);
+}
+
+#[test]
 fn provisioning_helper_does_not_commit_or_echo_a_raw_key_literal() {
     assert!(!PROVISIONING_HELPER.contains("QDRANT__SERVICE__API_KEY="));
     assert!(!PROVISIONING_HELPER.contains("echo \"${KEY_FILE}\""));

--- a/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
+++ b/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
@@ -13,12 +13,18 @@ macro_rules! include_packaging_asset {
     };
 }
 
+/// Returns the byte offset of the first occurrence of `needle` in
+/// `PROVISIONING_HELPER`, panicking if the needle is missing.
 macro_rules! helper_offset {
     ($needle:expr) => {
         PROVISIONING_HELPER.find($needle).expect("helper should contain expected text")
     };
 }
 
+/// Returns the byte offset of the first occurrence of `needle` in
+/// `PROVISIONING_HELPER` after `offset`, useful for ordering assertions.
+/// Panics if `offset` is not a valid UTF-8 boundary or if no matching
+/// occurrence exists after `offset`.
 macro_rules! helper_offset_after {
     ($needle:expr, $offset:expr) => {
         $offset
@@ -95,10 +101,14 @@ fn provisioning_helper_removes_stale_secret_before_generating_key_file() {
 fn provisioning_helper_uses_a_root_controlled_lock_path() {
     let lock_file = helper_offset!("/etc/repovec/repovec-qdrant-api-key.lock");
     let flock = helper_offset!("flock 9");
+    let debug_waiting = helper_offset!("debug_log \"waiting for ${LOCK_FILE}\"");
+    let debug_acquired = helper_offset!("debug_log \"acquired ${LOCK_FILE}\"");
 
     assert!(PROVISIONING_HELPER.contains("debug_log \"acquired ${LOCK_FILE}\""));
     assert!(PROVISIONING_HELPER.contains("debug_log \"released ${LOCK_FILE}\""));
     assert!(!PROVISIONING_HELPER.contains("LOCK_FILE=/var/lock/"));
+    assert!(debug_waiting < flock);
+    assert!(flock < debug_acquired);
     assert!(lock_file < flock);
 }
 

--- a/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
+++ b/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
@@ -13,6 +13,23 @@ macro_rules! include_packaging_asset {
     };
 }
 
+macro_rules! helper_offset {
+    ($needle:expr) => {
+        PROVISIONING_HELPER.find($needle).expect("helper should contain expected text")
+    };
+}
+
+macro_rules! helper_offset_after {
+    ($needle:expr, $offset:expr) => {
+        $offset
+            + PROVISIONING_HELPER
+                .get($offset..)
+                .expect("helper offset should be a valid byte boundary")
+                .find($needle)
+                .expect("helper should contain expected text after offset")
+    };
+}
+
 const PROVISIONING_SERVICE: &str =
     include_packaging_asset!("systemd/repovec-qdrant-api-key.service");
 const PROVISIONING_HELPER: &str = include_packaging_asset!("libexec/repovec-qdrant-api-key");
@@ -48,10 +65,18 @@ fn provisioning_helper_uses_the_canonical_secret_contract() {
 
 #[test]
 fn provisioning_helper_fails_closed_on_unexpected_secret_removal_errors() {
-    assert!(PROVISIONING_HELPER.contains("podman secret rm \"${SECRET_NAME}\""));
-    assert!(PROVISIONING_HELPER.contains("grep -qi 'in use' \"${rm_error}\""));
-    assert!(PROVISIONING_HELPER.contains("log \"podman secret removal failed: $(cat"));
-    assert!(PROVISIONING_HELPER.contains("exit 1"));
+    let removal = helper_offset!("podman secret rm \"${SECRET_NAME}\"");
+    let in_use_check = helper_offset!("grep -qi 'in use' \"${rm_error}\"");
+    let in_use_exit = helper_offset!("log \"podman secret is in use; leaving existing secret");
+    let unexpected_branch = helper_offset!("else\n            # Fail closed:");
+    let unexpected_log = helper_offset!("log \"podman secret removal failed: $(cat");
+    let unexpected_exit = helper_offset_after!("exit 1", unexpected_log);
+
+    assert!(removal < in_use_check);
+    assert!(in_use_check < in_use_exit);
+    assert!(in_use_exit < unexpected_branch);
+    assert!(unexpected_branch < unexpected_log);
+    assert!(unexpected_log < unexpected_exit);
 }
 
 #[test]
@@ -64,6 +89,26 @@ fn provisioning_helper_removes_stale_secret_before_generating_key_file() {
         .expect("helper should generate a missing key file");
 
     assert!(secret_removal < key_generation);
+}
+
+#[test]
+fn provisioning_helper_uses_flock_for_mutual_exclusion() {
+    let lock_file = helper_offset!("/var/lock/repovec-qdrant-api-key.lock");
+    let flock = helper_offset!("flock 9");
+    let secret_inspection = helper_offset!("podman secret inspect \"${SECRET_NAME}\"");
+    let secret_removal = helper_offset!("podman secret rm \"${SECRET_NAME}\"");
+    let missing_key_branch = helper_offset!("if [ ! -e \"${KEY_FILE}\" ]; then");
+    let key_generation = helper_offset_after!("generate_key_file", missing_key_branch);
+    let secret_creation = helper_offset!("podman secret create \"${SECRET_NAME}\"");
+
+    assert!(PROVISIONING_HELPER.contains("od -An -N32 -tx1"));
+    assert!(PROVISIONING_HELPER.contains("debug_log \"acquired ${LOCK_FILE}\""));
+    assert!(PROVISIONING_HELPER.contains("debug_log \"released ${LOCK_FILE}\""));
+    assert!(lock_file < flock);
+    assert!(flock < secret_inspection);
+    assert!(flock < secret_removal);
+    assert!(flock < key_generation);
+    assert!(flock < secret_creation);
 }
 
 #[test]

--- a/crates/repovec-core/src/appliance/qdrant_quadlet/snapshots/repovec_core__appliance__qdrant_quadlet__provisioning_tests__fail_closed_else_branch.snap
+++ b/crates/repovec-core/src/appliance/qdrant_quadlet/snapshots/repovec_core__appliance__qdrant_quadlet__provisioning_tests__fail_closed_else_branch.snap
@@ -1,0 +1,10 @@
+---
+source: crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
+expression: "helper_slice(start, end)"
+---
+else
+            # Fail closed: unexpected removal failures may leave stale
+            # credentials active, so the caller must see a non-zero status.
+            log "podman secret removal failed: $(cat "${rm_error}")"
+            release_lock
+            exit 1

--- a/crates/repovec-core/src/appliance/qdrant_quadlet/snapshots/repovec_core__appliance__qdrant_quadlet__provisioning_tests__lock_critical_section.snap
+++ b/crates/repovec-core/src/appliance/qdrant_quadlet/snapshots/repovec_core__appliance__qdrant_quadlet__provisioning_tests__lock_critical_section.snap
@@ -1,0 +1,15 @@
+---
+source: crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
+expression: "helper_slice(start, end)"
+---
+exec 9>"${LOCK_FILE}"
+debug_log "waiting for ${LOCK_FILE}"
+flock 9
+debug_log "acquired ${LOCK_FILE}"
+
+ensure_repovec_user
+install -d -o root -g "${REPOVEC_GROUP}" -m 0750 "${CONFIG_DIR}"
+
+if podman secret inspect "${SECRET_NAME}" >/dev/null 2>&1; then
+    rm_error="$(mktemp "${CONFIG_DIR}/qdrant-secret-rm.XXXXXX")"
+    trap 'rm -f "${rm_error}"; release_lock

--- a/crates/repovec-core/src/appliance/qdrant_quadlet/snapshots/repovec_core__appliance__qdrant_quadlet__provisioning_tests__release_lock_implementation.snap
+++ b/crates/repovec-core/src/appliance/qdrant_quadlet/snapshots/repovec_core__appliance__qdrant_quadlet__provisioning_tests__release_lock_implementation.snap
@@ -1,0 +1,8 @@
+---
+source: crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs
+expression: "helper_slice(start, end)"
+---
+release_lock() {
+    flock -u 9
+    debug_log "released ${LOCK_FILE}"
+}

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -249,7 +249,6 @@ that those assets expose.
 
 #### Mutual exclusion in the provisioning helper
 
-
 ##### `LOCK_FILE`
 
 The helper uses `/etc/repovec/repovec-qdrant-api-key.lock` as its lock file.
@@ -259,7 +258,6 @@ rather than `/var/lock` because `/etc/repovec` is a root-owned directory with
 mode `0750` that is not world-writable.  This prevents unprivileged users from
 substituting the lock file in a way that could interfere with the mutual
 exclusion protocol.
-
 
 ##### Critical section boundaries
 
@@ -272,7 +270,6 @@ the explicit `release_lock` helper, which calls `flock -u 9` and emits a debug
 log.  Signal handlers on `EXIT`, `HUP`, `INT`, and `TERM` also call
 `release_lock` before cleaning up temporary files, ensuring the lock is not
 held by a signal-interrupted process for longer than necessary.
-
 
 ##### Fail-closed invariant
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -279,6 +279,22 @@ caller observes a failure rather than silently proceeding with the existing
 secret, which might be stale or compromised.  The "in use" case exits zero
 because the existing secret remains valid and usable.
 
+##### Debug logging
+
+Setting `REPOVEC_DEBUG=1` causes the helper to emit debug-level log lines to
+stderr via the internal `debug_log()` function.  When enabled, the helper logs
+when it is waiting to acquire the lock, when it has acquired the lock, and when
+it has released the lock.  `REPOVEC_DEBUG` is intended for local
+troubleshooting only and must not be set in production service units.
+
+The `debug_log()` function is internal to the provisioning helper.  It writes a
+line to stderr when `REPOVEC_DEBUG=1` is set; under the systemd service, the
+journal timestamps that stderr line.  It is not a public API, and callers
+outside the provisioning helper must not rely on its output format.  Every lock
+lifecycle event (waiting to acquire, acquired, and released) is instrumented
+through this function, and its output is suppressed when `REPOVEC_DEBUG` is
+unset or set to any value other than `1`.
+
 ### 5.3 `systemd_units` validation surface
 
 The `systemd_units` module exposes the public validation surface for the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -247,6 +247,41 @@ The helper is host-facing packaging code. It owns filesystem, user, permission
 and Podman-secret operations; `repovec-core` only validates the static contract
 that those assets expose.
 
+#### Mutual exclusion in the provisioning helper
+
+
+##### `LOCK_FILE`
+
+The helper uses `/etc/repovec/repovec-qdrant-api-key.lock` as its lock file.
+It opens the file on descriptor 9 with `exec 9>"${LOCK_FILE}"` and acquires an
+exclusive lock via `flock 9`.  The lock file is placed in `/etc/repovec`
+rather than `/var/lock` because `/etc/repovec` is a root-owned directory with
+mode `0750` that is not world-writable.  This prevents unprivileged users from
+substituting the lock file in a way that could interfere with the mutual
+exclusion protocol.
+
+
+##### Critical section boundaries
+
+The lock is acquired after the initial `install -d -o root -g root` bootstrap
+step.  That bootstrap runs unlocked so the lock file's parent directory already
+exists when the helper attempts to open it.  Once held, the lock covers
+`ensure_repovec_user`, the group-ownership `install -d`, secret inspection,
+secret removal, key generation, and secret creation.  The lock is released via
+the explicit `release_lock` helper, which calls `flock -u 9` and emits a debug
+log.  Signal handlers on `EXIT`, `HUP`, `INT`, and `TERM` also call
+`release_lock` before cleaning up temporary files, ensuring the lock is not
+held by a signal-interrupted process for longer than necessary.
+
+
+##### Fail-closed invariant
+
+Unexpected failures from `podman secret rm` (anything other than "in use")
+cause the helper to exit non-zero.  This fail-closed behaviour ensures the
+caller observes a failure rather than silently proceeding with the existing
+secret, which might be stale or compromised.  The "in use" case exits zero
+because the existing secret remains valid and usable.
+
 ### 5.3 `systemd_units` validation surface
 
 The `systemd_units` module exposes the public validation surface for the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,7 +72,7 @@ with API-key authentication, and survives host reboots.
   - Status: complete. The repository now ships a provisioning service, helper,
     sysusers declaration, authenticated Quadlet wiring and Rust validation for
     the static API-key contract. Concurrent-invocation hardening (flock-based
-    serialisation, fail-closed secret-removal, and lock-lifecycle tests) was
+    serialization, fail-closed secret-removal, and lock-lifecycle tests) was
     added in `#29`.
 - [ ] 1.2.3. Validate Qdrant liveness from Rust
   - Implement a health-check function in `repovec-core` that connects to

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -71,7 +71,9 @@ with API-key authentication, and survives host reboots.
   - Success criteria: unauthenticated requests to Qdrant are rejected.
   - Status: complete. The repository now ships a provisioning service, helper,
     sysusers declaration, authenticated Quadlet wiring and Rust validation for
-    the static API-key contract.
+    the static API-key contract. Concurrent-invocation hardening (flock-based
+    serialisation, fail-closed secret-removal, and lock-lifecycle tests) was
+    added in `#29`.
 - [ ] 1.2.3. Validate Qdrant liveness from Rust
   - Implement a health-check function in `repovec-core` that connects to
     Qdrant gRPC at `localhost:6334` with the stored API key and confirms the

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -117,7 +117,6 @@ Requests to Qdrant without the `api-key` header are rejected.
 
 ### Qdrant API-key provisioning behaviour
 
-
 #### `REPOVEC_DEBUG` environment variable
 
 Setting `REPOVEC_DEBUG=1` enables debug-level log lines emitted to stderr by
@@ -126,7 +125,6 @@ acquisition and release events alongside other diagnostic output.  This
 variable is intended for troubleshooting only.  It must not be set in
 production systemd service units, and the default behaviour (no debug output)
 is safe for production.
-
 
 #### Flock-based serialisation
 
@@ -138,7 +136,6 @@ creation.  The lock file is owned by `root:root` and resides in `/etc/repovec`,
 a root-owned directory with mode `0750` that is not world-writable.  This
 ensures that an unprivileged process cannot substitute the lock file to
 interfere with serialisation.
-
 
 #### Fail-closed secret-removal behaviour
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -126,16 +126,16 @@ variable is intended for troubleshooting only.  It must not be set in
 production systemd service units, and the default behaviour (no debug output)
 is safe for production.
 
-#### Flock-based serialisation
+#### Flock-based serialization
 
-The `repovec-qdrant-api-key` helper serialises all mutable operations behind an
+The `repovec-qdrant-api-key` helper serializes all mutable operations behind an
 exclusive `flock` on `/etc/repovec/repovec-qdrant-api-key.lock`.  Concurrent
 invocations block until the lock is available, preventing races between user
 creation, directory creation, secret inspection, key generation, and secret
 creation.  The lock file is owned by `root:root` and resides in `/etc/repovec`,
 a root-owned directory with mode `0750` that is not world-writable.  This
 ensures that an unprivileged process cannot substitute the lock file to
-interfere with serialisation.
+interfere with serialization.
 
 #### Fail-closed secret-removal behaviour
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -115,6 +115,42 @@ EOF'
 
 Requests to Qdrant without the `api-key` header are rejected.
 
+### Qdrant API-key provisioning behaviour
+
+
+#### `REPOVEC_DEBUG` environment variable
+
+Setting `REPOVEC_DEBUG=1` enables debug-level log lines emitted to stderr by
+the `repovec-qdrant-api-key` helper.  When enabled, the helper logs lock
+acquisition and release events alongside other diagnostic output.  This
+variable is intended for troubleshooting only.  It must not be set in
+production systemd service units, and the default behaviour (no debug output)
+is safe for production.
+
+
+#### Flock-based serialisation
+
+The `repovec-qdrant-api-key` helper serialises all mutable operations behind an
+exclusive `flock` on `/etc/repovec/repovec-qdrant-api-key.lock`.  Concurrent
+invocations block until the lock is available, preventing races between user
+creation, directory creation, secret inspection, key generation, and secret
+creation.  The lock file is owned by `root:root` and resides in `/etc/repovec`,
+a root-owned directory with mode `0750` that is not world-writable.  This
+ensures that an unprivileged process cannot substitute the lock file to
+interfere with serialisation.
+
+
+#### Fail-closed secret-removal behaviour
+
+If `podman secret rm` fails for any reason other than the secret being in use,
+the helper exits non-zero.  The caller (systemd) sees a unit failure rather
+than silently continuing with stale credentials.  When the removal fails
+because the secret is in use (`podman secret rm` reports "in use"), the helper
+exits zero because the existing secret remains valid and does not need to be
+replaced.  This fail-closed invariant ensures that an unexpected removal error
+never results in the Qdrant Quadlet running with an outdated or missing API
+key.
+
 ### Qdrant Quadlet validation diagnostics
 
 `repovec_core::appliance::qdrant_quadlet` exposes `validate_qdrant_quadlet` and

--- a/packaging/libexec/repovec-qdrant-api-key
+++ b/packaging/libexec/repovec-qdrant-api-key
@@ -61,6 +61,8 @@ generate_key_file() {
     trap - EXIT HUP INT TERM
 }
 
+install -d -o root -g root -m 0750 "${CONFIG_DIR}"
+
 exec 9>"${LOCK_FILE}"
 debug_log "waiting for ${LOCK_FILE}"
 flock 9

--- a/packaging/libexec/repovec-qdrant-api-key
+++ b/packaging/libexec/repovec-qdrant-api-key
@@ -45,7 +45,7 @@ ensure_repovec_user() {
 
 generate_key_file() {
     tmp_file="$(mktemp "${CONFIG_DIR}/qdrant-api-key.XXXXXX")"
-    trap 'rm -f "${tmp_file}"' EXIT HUP INT TERM
+    trap 'rm -f "${tmp_file}"; release_lock' EXIT HUP INT TERM
 
     log "generating qdrant API key file"
     candidate_key="$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')"
@@ -73,7 +73,7 @@ install -d -o root -g "${REPOVEC_GROUP}" -m 0750 "${CONFIG_DIR}"
 
 if podman secret inspect "${SECRET_NAME}" >/dev/null 2>&1; then
     rm_error="$(mktemp "${CONFIG_DIR}/qdrant-secret-rm.XXXXXX")"
-    trap 'rm -f "${rm_error}"' EXIT HUP INT TERM
+    trap 'rm -f "${rm_error}"; release_lock' EXIT HUP INT TERM
     if ! podman secret rm "${SECRET_NAME}" > /dev/null 2>"${rm_error}"; then
         if grep -qi 'in use' "${rm_error}"; then
             log "podman secret is in use; leaving existing secret in place"
@@ -103,7 +103,7 @@ chmod 0400 "${KEY_FILE}"
 log "ensured qdrant API key permissions"
 
 create_error="$(mktemp "${CONFIG_DIR}/qdrant-secret-create.XXXXXX")"
-trap 'rm -f "${create_error}"' EXIT HUP INT TERM
+trap 'rm -f "${create_error}"; release_lock' EXIT HUP INT TERM
 if ! podman secret create "${SECRET_NAME}" "${KEY_FILE}" >/dev/null 2>"${create_error}"; then
     log "podman secret creation failed: $(cat "${create_error}")"
     release_lock

--- a/packaging/libexec/repovec-qdrant-api-key
+++ b/packaging/libexec/repovec-qdrant-api-key
@@ -61,13 +61,13 @@ generate_key_file() {
     trap - EXIT HUP INT TERM
 }
 
-ensure_repovec_user
-install -d -o root -g "${REPOVEC_GROUP}" -m 0750 "${CONFIG_DIR}"
-
 exec 9>"${LOCK_FILE}"
 debug_log "waiting for ${LOCK_FILE}"
 flock 9
 debug_log "acquired ${LOCK_FILE}"
+
+ensure_repovec_user
+install -d -o root -g "${REPOVEC_GROUP}" -m 0750 "${CONFIG_DIR}"
 
 if podman secret inspect "${SECRET_NAME}" >/dev/null 2>&1; then
     rm_error="$(mktemp "${CONFIG_DIR}/qdrant-secret-rm.XXXXXX")"

--- a/packaging/libexec/repovec-qdrant-api-key
+++ b/packaging/libexec/repovec-qdrant-api-key
@@ -12,7 +12,7 @@ REPOVEC_USER=repovec
 REPOVEC_GROUP=repovec
 CONFIG_DIR=/etc/repovec
 KEY_FILE=/etc/repovec/qdrant-api-key
-LOCK_FILE=/var/lock/repovec-qdrant-api-key.lock
+LOCK_FILE=/etc/repovec/repovec-qdrant-api-key.lock
 SECRET_NAME=repovec-qdrant-api-key
 
 log() {

--- a/packaging/libexec/repovec-qdrant-api-key
+++ b/packaging/libexec/repovec-qdrant-api-key
@@ -12,10 +12,22 @@ REPOVEC_USER=repovec
 REPOVEC_GROUP=repovec
 CONFIG_DIR=/etc/repovec
 KEY_FILE=/etc/repovec/qdrant-api-key
+LOCK_FILE=/var/lock/repovec-qdrant-api-key.lock
 SECRET_NAME=repovec-qdrant-api-key
 
 log() {
     printf '%s\n' "repovec-qdrant-api-key: $*" >&2
+}
+
+debug_log() {
+    if [ "${REPOVEC_DEBUG:-}" = "1" ]; then
+        log "debug: $*"
+    fi
+}
+
+release_lock() {
+    flock -u 9
+    debug_log "released ${LOCK_FILE}"
 }
 
 ensure_repovec_user() {
@@ -39,6 +51,7 @@ generate_key_file() {
     candidate_key="$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')"
     if [ "${#candidate_key}" -ne 64 ] || printf '%s' "${candidate_key}" | grep -q '[^0-9a-fA-F]'; then
         log "failed to generate a valid qdrant API key"
+        release_lock
         exit 1
     fi
     printf '%s' "${candidate_key}" >"${tmp_file}"
@@ -51,16 +64,26 @@ generate_key_file() {
 ensure_repovec_user
 install -d -o root -g "${REPOVEC_GROUP}" -m 0750 "${CONFIG_DIR}"
 
+exec 9>"${LOCK_FILE}"
+debug_log "waiting for ${LOCK_FILE}"
+flock 9
+debug_log "acquired ${LOCK_FILE}"
+
 if podman secret inspect "${SECRET_NAME}" >/dev/null 2>&1; then
     rm_error="$(mktemp "${CONFIG_DIR}/qdrant-secret-rm.XXXXXX")"
     trap 'rm -f "${rm_error}"' EXIT HUP INT TERM
     if ! podman secret rm "${SECRET_NAME}" > /dev/null 2>"${rm_error}"; then
         if grep -qi 'in use' "${rm_error}"; then
             log "podman secret is in use; leaving existing secret in place"
+            release_lock
             exit 0
+        else
+            # Fail closed: unexpected removal failures may leave stale
+            # credentials active, so the caller must see a non-zero status.
+            log "podman secret removal failed: $(cat "${rm_error}")"
+            release_lock
+            exit 1
         fi
-        log "podman secret removal failed: $(cat "${rm_error}")"
-        exit 1
     fi
     rm -f "${rm_error}"
     trap - EXIT HUP INT TERM
@@ -81,8 +104,10 @@ create_error="$(mktemp "${CONFIG_DIR}/qdrant-secret-create.XXXXXX")"
 trap 'rm -f "${create_error}"' EXIT HUP INT TERM
 if ! podman secret create "${SECRET_NAME}" "${KEY_FILE}" >/dev/null 2>"${create_error}"; then
     log "podman secret creation failed: $(cat "${create_error}")"
+    release_lock
     exit 1
 fi
 rm -f "${create_error}"
 trap - EXIT HUP INT TERM
 log "created qdrant API-key podman secret"
+release_lock


### PR DESCRIPTION
## Summary

This branch serializes the Qdrant API-key provisioning helper so concurrent invocations cannot race while inspecting, removing, generating, repairing or creating the Podman secret material.

Closes #29.

## Review walkthrough

- Start with [packaging/libexec/repovec-qdrant-api-key](https://github.com/leynos/repovec-appliance/blob/66bbd898b72a54820a3744ceaca15bf330c11e9f/packaging/libexec/repovec-qdrant-api-key) to review the blocking `flock` critical section, explicit unlock helper and fail-closed secret-removal branch.
- Then review [crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs](https://github.com/leynos/repovec-appliance/blob/66bbd898b72a54820a3744ceaca15bf330c11e9f/crates/repovec-core/src/appliance/qdrant_quadlet/provisioning_tests.rs) for the static provisioning-helper invariants covering lock ordering and unexpected removal errors.

## Validation

- `make check-fmt`: passed
- `make lint`: passed
- `make test`: passed, including 149 nextest tests plus doctests
- `coderabbit review --agent`: blocked twice by CodeRabbit service rate limits after retrying; the second response reported a further 5 minute 40 second wait.

## Summary by Sourcery

Serialize Qdrant API key provisioning to be mutually exclusive and fail closed on secret removal errors.

New Features:
- Add flock-based mutual exclusion around Qdrant API key provisioning and secret management.

Enhancements:
- Strengthen the provisioning helper to handle unexpected secret removal errors in a fail-closed manner.

Tests:
- Extend provisioning helper tests to validate lock usage, operation ordering, and fail-closed behavior on secret removal errors.