### PR TITLE
Add scheduled mutation testing via the shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,13 @@ jobs:
           whitaker-installer
       - name: Lint
         run: make lint
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          python-version: '3.13'
+          enable-cache: true
+      - name: Workflow contract tests
+        run: make test-workflow-contracts
 
   test:
     name: test

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,33 @@
+name: Mutation testing
+
+# Thin caller of the shared mutation-testing reusable workflow; caller
+# guide: leynos/shared-actions docs/mutation-cargo-workflow.md.
+on:
+  schedule:
+    - cron: "5 11 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mutation:
+    permissions:
+      contents: read
+      id-token: write # OIDC workflow-source resolution
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@859416a90eb3987b46a57682c5d6b8964ad3f0a6
+    with:
+      # All Rust source lives in the cargo workspace under crates/; the
+      # integration-tests/ directory is a Python harness and is not a
+      # mutation target.
+      paths: "crates/"
+      # repovec-test-helpers is a dev-dependency fixture crate consumed
+      # only by other crates' tests; mutating it yields noise survivors.
+      exclude-globs: "crates/repovec-test-helpers/**"
+      # CI tests with --all-features across the whole workspace, and
+      # library crates are covered by dependent crates' tests, so run
+      # the full workspace suite against each mutant.
+      extra-args: "--all-features --test-workspace=true"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ integration-tests/.venv/
 integration-tests/**/__pycache__/
 integration-tests/.pytest_cache/
 integration-tests/*.egg-info/
+
+# Workflow contract tests
+tests/**/__pycache__/
+.pytest_cache/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint whitaker-lint typecheck fmt check-fmt markdownlint docs docs-lint docs-check ensure-cargo nixie validate-systemd integration-test integration-command-test _check-python _check-integration-prereqs _check-command-test-prereqs
+.PHONY: help all clean test build release lint whitaker-lint typecheck fmt check-fmt markdownlint docs docs-lint docs-check ensure-cargo nixie validate-systemd integration-test integration-command-test test-workflow-contracts _check-python _check-integration-prereqs _check-command-test-prereqs
 
 
 CARGO ?= $(or $(shell command -v cargo 2>/dev/null),$(HOME)/.cargo/bin/cargo)
@@ -114,6 +114,9 @@ integration-test: _check-integration-prereqs ## Run testcontainers-based provisi
 
 integration-command-test: _check-command-test-prereqs ## Run cmd-mox-based command-contract tests
 	cd $(INTEGRATION_TESTS_DIR) && "$(PYTHON)" -m pytest -m cmd_mox provisioning $(PYTEST_FLAGS)
+
+test-workflow-contracts: ## Validate the mutation-testing caller contract
+	uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -1,0 +1,150 @@
+"""Contract tests for the mutation-testing caller workflow.
+
+The executable logic lives in the ``leynos/shared-actions`` reusable
+workflow, which carries its own unit and integration tests;
+repovec-appliance's caller is declarative configuration. These tests
+parse the caller with PyYAML and pin the contract it must uphold, so
+drift (repointing the pin at a branch, widening permissions, or losing
+the workspace-wide test configuration) fails CI on the pull request
+rather than surfacing in a scheduled or manual run.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
+)
+
+pytestmark = pytest.mark.skipif(
+    not WORKFLOW_PATH.exists(),
+    reason="workflow file not present in this working copy (e.g. "
+    "inside mutmut's mutants/ sandbox, which does not copy .github/)",
+)
+
+#: The leynos/shared-actions commit the caller pins. Bump the caller and
+#: this test together.
+PINNED_SHA = "859416a90eb3987b46a57682c5d6b8964ad3f0a6"
+
+EXPECTED_USES = (
+    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+)
+
+#: The exact caller configuration: the cargo workspace lives under
+#: crates/ (integration-tests/ is a Python harness, not a mutation
+#: target), repovec-test-helpers is dev-dependency scaffolding, and CI
+#: runs the whole workspace's tests with --all-features.
+EXPECTED_WITH = {
+    "paths": "crates/",
+    "exclude-globs": "crates/repovec-test-helpers/**",
+    "extra-args": "--all-features --test-workspace=true",
+}
+
+
+def _load() -> dict[str, object]:
+    """Parse the workflow file."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the ``on:`` mapping (PyYAML parses the bare key as True)."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+    return triggers
+
+
+def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
+    assert jobs, "the workflow must declare at least one job"
+    assert list(jobs) == ["mutation"], (
+        f"expected a single job named 'mutation', found {sorted(jobs)}"
+    )
+    return jobs["mutation"]
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+    """The job must call the shared workflow at the exact documented SHA."""
+    uses = _mutation_job(_load()).get("uses")
+    assert uses is not None, "jobs.mutation.uses is missing"
+    path, _, ref = uses.partition("@")
+    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
+        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
+    )
+    assert len(ref) == 40, (
+        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in ref), (
+        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert uses == EXPECTED_USES, (
+        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
+        "bump the caller and this test together"
+    )
+
+
+def test_job_permissions_are_exactly_least_privilege() -> None:
+    """The job grants contents: read and id-token: write, nothing broader."""
+    permissions = _mutation_job(_load()).get("permissions")
+    assert permissions == {"contents": "read", "id-token": "write"}, (
+        "jobs.mutation.permissions must be exactly "
+        f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
+    )
+
+
+def test_workflow_default_permissions_are_empty() -> None:
+    """The workflow-level default token scope is empty."""
+    workflow = _load()
+    assert workflow.get("permissions") == {}, (
+        f"top-level permissions must be an empty mapping, got "
+        f"{workflow.get('permissions')!r}"
+    )
+
+
+def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+    """Runs queue per ref instead of cancelling one another."""
+    concurrency = _load().get("concurrency")
+    assert isinstance(concurrency, dict), "the workflow must declare concurrency"
+    assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
+        f"concurrency.group must key on the triggering ref, got "
+        f"{concurrency.get('group')!r}"
+    )
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"concurrency.cancel-in-progress must be false, got "
+        f"{concurrency.get('cancel-in-progress')!r}"
+    )
+
+
+def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+    """The daily schedule stays; dispatch has no legacy branch input."""
+    triggers = _triggers(_load())
+    schedule = triggers.get("schedule")
+    assert schedule == [{"cron": "5 11 * * *"}], (
+        f"on.schedule must be the daily 11:05 UTC cron, got {schedule!r}"
+    )
+    assert "workflow_dispatch" in triggers, "on.workflow_dispatch is missing"
+    dispatch = triggers.get("workflow_dispatch") or {}
+    inputs = dispatch.get("inputs") or {}
+    assert "branch" not in inputs, (
+        "on.workflow_dispatch must not declare a branch input; the Actions "
+        "run-workflow control selects the ref"
+    )
+
+
+def test_with_block_carries_the_caller_configuration() -> None:
+    """The caller passes exactly the paths, excludes, and feature args."""
+    with_block = _mutation_job(_load()).get("with")
+    assert isinstance(with_block, dict), "jobs.mutation.with is missing"
+    assert with_block == EXPECTED_WITH, (
+        "jobs.mutation.with must be exactly the documented configuration "
+        f"{EXPECTED_WITH!r}, got {with_block!r}"
+    )


### PR DESCRIPTION
## Summary

This pull request enrols repovec-appliance in the estate-wide mutation-testing rollout. It adds a thin caller of the [leynos/shared-actions mutation-cargo.yml reusable workflow](https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md), pinned to `859416a90eb3987b46a57682c5d6b8964ad3f0a6`, following the estate template established in [leynos/wireframe#572](https://github.com/leynos/wireframe/pull/572). The workflow is informational only: it runs a daily change-scoped guard at 11:05 UTC plus sharded full runs on manual dispatch, and does not gate pull requests.

## Configuration

The caller ([`.github/workflows/mutation-testing.yml`](https://github.com/leynos/repovec-appliance/blob/add-mutation-testing/.github/workflows/mutation-testing.yml)) sets three inputs:

- `paths: "crates/"` — all mutable Rust source lives in the cargo workspace under `crates/`; the `integration-tests/` directory is a Python harness and is not a mutation target.
- `exclude-globs: "crates/repovec-test-helpers/**"` — `repovec-test-helpers` is a dev-dependency fixture crate (log-capture and startup-assertion helpers) consumed only by other crates' tests; mutating it would produce noise survivors.
- `extra-args: "--all-features --test-workspace=true"` — CI's baseline (`make test`) runs the whole workspace with `--all-features`, and library crates such as `repovec-core` are covered by dependent crates' tests, so each mutant must run against the full workspace suite rather than only the mutated package's tests.

A contract test ([`tests/workflow_contracts/mutation_testing_test.py`](https://github.com/leynos/repovec-appliance/blob/add-mutation-testing/tests/workflow_contracts/mutation_testing_test.py)) parses the caller with PyYAML and pins the SHA, least-privilege permissions, per-ref non-cancelling concurrency, the cron slot, and the exact `with:` block, so drift fails CI on the pull request. The lint CI job gains a pinned `astral-sh/setup-uv` step and runs the new `test-workflow-contracts` Makefile target.

## Validation

- YAML parse of both workflow files passes.
- `actionlint` on both workflow files passes.
- `make test-workflow-contracts`: 6 passed, including a negative test (pin temporarily changed to `@v1` failed the SHA assertion as expected, then restored to green).
- Baseline verification: plain `cargo test --workspace --all-features` (the way cargo-mutants runs tests, including doctests skipped by nextest's `--all-targets`) passes locally.
