### PR TITLE
Adopt the Whitaker Dylint suite in the lint gate and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,7 @@ name: CI
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_BINSTALL_VERSION: '1.15.7'
-  WHITAKER_INSTALLER_VERSION: '0.2.1'
+  WHITAKER_INSTALLER_VERSION: '0.2.5'
 
 jobs:
   build:
@@ -82,15 +81,13 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          if command -v cargo-binstall >/dev/null 2>&1; then
-            echo "cargo-binstall already present"
-          else
-            cargo install cargo-binstall --locked --version "${{ env.CARGO_BINSTALL_VERSION }}"
-          fi
-          if command -v whitaker-installer >/dev/null 2>&1; then
-            echo "whitaker-installer already present; skipping cargo binstall"
-          else
-            cargo binstall --no-confirm whitaker-installer@${{ env.WHITAKER_INSTALLER_VERSION }}
+          if ! command -v whitaker-installer >/dev/null 2>&1; then
+            if cargo binstall --version >/dev/null 2>&1; then
+              cargo binstall --no-confirm --locked "whitaker-installer@${WHITAKER_INSTALLER_VERSION}"
+            else
+              echo "cargo-binstall unavailable; building whitaker-installer from crates.io"
+              cargo install --locked whitaker-installer --version "${WHITAKER_INSTALLER_VERSION}"
+            fi
           fi
           whitaker-installer
       - name: Lint

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 
 CARGO ?= $(or $(shell command -v cargo 2>/dev/null),$(HOME)/.cargo/bin/cargo)
+WHITAKER ?= whitaker
 PYTHON ?= python3
 INTEGRATION_TESTS_DIR ?= integration-tests
 PYTEST_FLAGS ?=
@@ -49,14 +50,14 @@ test: ensure-cargo ## Run tests with warnings treated as errors
 		RUSTFLAGS="$(EFFECTIVE_RUST_FLAGS)" $(CARGO) test --doc $(DOCTEST_FLAGS) $(BUILD_JOBS); \
 	fi
 
-lint: ensure-cargo ## Run Clippy with warnings denied
+lint: ensure-cargo ## Run Clippy and the Whitaker Dylint suite with warnings denied
 	RUSTDOCFLAGS="$(EFFECTIVE_RUSTDOC_FLAGS)" $(CARGO) doc --no-deps --workspace
 	$(CARGO) clippy --workspace $(CLIPPY_FLAGS)
 	$(MAKE) whitaker-lint
 
-whitaker-lint: ## Run Whitaker when available
-	@if command -v whitaker >/dev/null 2>&1; then \
-		RUSTFLAGS="$(EFFECTIVE_RUST_FLAGS)" whitaker --all -- $(CARGO_FLAGS); \
+whitaker-lint: ## Run the Whitaker Dylint suite when available
+	@if command -v "$(WHITAKER)" >/dev/null 2>&1; then \
+		RUSTFLAGS="$(EFFECTIVE_RUST_FLAGS)" $(WHITAKER) --all -- $(CARGO_FLAGS); \
 	else \
 		echo "whitaker not found on PATH; skipping whitaker lint. Install whitaker to run this check."; \
 	fi


### PR DESCRIPTION
## Summary

This change aligns repovec-appliance's existing Whitaker Dylint adoption with
the estate-wide rollout pattern established in leynos/netsuke#410. The
Makefile gains a `WHITAKER ?= whitaker` tool variable so the suite binary can
be overridden like the other tools, and the lint targets' help text now
mentions Whitaker. The pinned installer is bumped from 0.2.1 to 0.2.5. The CI
install step is hardened: the inline `${{ env… }}` interpolations inside the
run block are replaced with plain shell variable indirection (zizmor flags
the inline form as template injection), the installer fetch is pinned with
`--locked`, and the bespoke cargo-binstall bootstrap is replaced by the
standard binstall-or-build fallback so the step still succeeds on runners
whose Rust setup does not provide `cargo binstall`.

The suite reports no findings on the workspace; the codebase was already
Whitaker-clean.

## Review walkthrough

- [Makefile](https://github.com/leynos/repovec-appliance/blob/adopt-whitaker/Makefile)
  — adds the `WHITAKER` tool variable and uses it in the `whitaker-lint`
  recipe invoked from `lint`.
- [.github/workflows/ci.yml](https://github.com/leynos/repovec-appliance/blob/adopt-whitaker/.github/workflows/ci.yml)
  — installer bumped to 0.2.5 and the install step rewritten with
  shell-variable indirection, `--locked`, and the binstall-or-build
  fallback.

## Validation

- `whitaker --all -- --all-targets --all-features` with
  `RUSTFLAGS="-D warnings"` — exit 0, no findings.
- `make check-fmt lint typecheck test markdownlint validate-systemd` — all
  gates pass (nextest and doctest suites green, Markdown lint clean, systemd
  unit contract satisfied).
- `uv run pytest lib/tests -q` in `integration-tests/` — 26 passed.
