### PR TITLE
Stop pinning the mutation-cargo caller to an exact shared-actions SHA

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -115,6 +115,42 @@ the gate is a fatal CI failure.
 Run `make validate-systemd` locally before proposing a change to any file under
 `packaging/systemd/` or `crates/repovec-core/src/appliance/systemd_units/`.
 
+### 2.1 Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 ## 3. CI policy helper
 
 ### 3.1 Public API

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -8,11 +8,17 @@ drift (repointing the pin at a branch, widening permissions, or losing
 the workspace-wide test configuration) fails CI on the pull request
 rather than surfacing in a scheduled or manual run.
 
+The caller must reference the correct reusable workflow at a commit
+SHA; Dependabot owns the SHA value, so these tests assert the shape of
+the pin (the reusable workflow path, and a 40-hex commit SHA rather
+than a mutable branch or tag) without asserting which SHA is pinned.
+
 Run via ``make test-workflow-contracts``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -28,12 +34,10 @@ pytestmark = pytest.mark.skipif(
     "inside mutmut's mutants/ sandbox, which does not copy .github/)",
 )
 
-#: The leynos/shared-actions commit the caller pins. Bump the caller and
-#: this test together.
-PINNED_SHA = "859416a90eb3987b46a57682c5d6b8964ad3f0a6"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+#: The caller must reference this reusable workflow, pinned to a 40-hex
+#: commit SHA. Dependabot owns the SHA value; do not assert which SHA.
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$"
 )
 
 #: The exact caller configuration: the cargo workspace lives under
@@ -70,25 +74,18 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call the shared workflow pinned to a commit SHA.
+
+    The exact SHA is Dependabot's to bump; this only asserts the shape:
+    the correct reusable-workflow path, pinned to a 40-hex commit SHA
+    rather than a mutable branch or tag such as ``main`` or ``rolling``.
+    """
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
-        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump the caller and this test together"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation.uses must reference mutation-cargo.yml pinned to a "
+        f"40-hex commit SHA, got {uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- Replace the exact-SHA equality assertion in the mutation-testing caller contract test with a shape assertion, so a Dependabot bump of the `leynos/shared-actions` pin no longer fails CI in lockstep.
- Document the shape-only pinning policy in the developers' guide.

## Review walkthrough

- `tests/workflow_contracts/mutation_testing_test.py`: dropped the `PINNED_SHA` constant, the `EXPECTED_USES` equality target, and the doc-comment instructing maintainers to bump the caller and the test together. `test_uses_reference_is_pinned_to_the_documented_sha` is renamed to `test_uses_reference_is_pinned_to_a_commit_sha` and now matches `jobs.mutation.uses` against a regex asserting the correct reusable workflow path (`leynos/shared-actions/.github/workflows/mutation-cargo.yml`) pinned to a 40-hex commit SHA, without asserting which SHA. The module docstring is updated to describe this. All other assertions (job permissions, workflow-level default permissions, concurrency group, triggers, and the `with:` block) are unchanged.
- `docs/developers-guide.md`: new subsection 2.1, "Workflow pins and Dependabot", documenting that Dependabot owns the SHA value and that contract tests must assert shape (correct path, 40-hex commit SHA) rather than a specific SHA.
- No workflow files or pinned SHA values were touched — Dependabot continues to own `.github/workflows/mutation-testing.yml`'s pin from here on.
- `.github/dependabot.yml` already has a `github-actions` ecosystem entry with `directory: "/"`; no change needed there.

## Validation

- `make test-workflow-contracts` passes locally, confirming the regex matches the currently pinned SHA (`859416a90eb3987b46a57682c5d6b8964ad3f0a6`); the regex (`[0-9a-f]{40}` anchored to end of string) also matches any other well-formed 40-hex SHA, so a future Dependabot bump will not break this test.
- `make spelling` and `make markdownlint` pass locally against the updated developers' guide.
