### PR TITLE
Bump whitaker-installer to 0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: CI
 
 env:
   CARGO_TERM_COLOR: always
-  WHITAKER_INSTALLER_VERSION: '0.2.5'
+  WHITAKER_INSTALLER_VERSION: '0.2.6'
 
 jobs:
   spelling:


### PR DESCRIPTION
This change bumps the pinned `whitaker-installer` version from 0.2.5 to 0.2.6 in the CI workflow, because the Whitaker Dylint suite's rolling release now pins toolchain `nightly-2026-05-28`, which requires `cargo-dylint` 6.0.1. Installer 0.2.5 provisions `cargo-dylint` 4.1.0, whose driver cannot compile against that nightly, leaving the repository's CI lint step red. Installer 0.2.6 provisions `cargo-dylint` 6.0.1 and its prebuilt dependency binaries are now published, which resolves the failure.

## Changed files

- [`.github/workflows/ci.yml`](https://github.com/leynos/repovec-appliance/blob/bump-whitaker-installer-0.2.6/.github/workflows/ci.yml)
