### PR TITLE
Document mutation-testing workflow contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -151,6 +151,10 @@ If a workflow's behaviour genuinely depends on a feature only present from a
 particular commit onwards, express that as a comment or a changelog note, not
 as a test assertion on the SHA string.
 
+The [mutation-testing workflow contract
+tests](#mutation-testing-workflow-contract-tests) apply this shape-only
+policy to the `mutation-cargo.yml` caller.
+
 ## 3. CI policy helper
 
 ### 3.1 Public API
@@ -755,3 +759,64 @@ Unit tests should use `rstest` fixtures. Behavioural tests should use
 `oauth2-test-server`, completes a local device-flow exchange, stores the token
 through the encrypted-store boundary, reloads it, and verifies the same token
 secret is recovered.
+
+## Mutation-testing workflow contract tests
+
+This repository runs scheduled, informational mutation testing through a thin
+caller workflow,
+[`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-cargo.yml`. The heavy
+lifting — running `cargo-mutants`, sharding, and summarizing survivors — lives
+in `shared-actions`; this repository carries only declarative configuration.
+The run is **informational only**: it never gates a pull request. Survivors
+are reported through the job summary and downloadable artefacts so they can
+be triaged into tests, not enforced as a blocking check.
+
+The workflow runs in two modes. A **daily schedule** fires a change-scoped
+run that mutates only the source files touched within the detection window,
+so quiet days are cheap no-ops. A **manual dispatch** (the Actions "Run
+workflow" control) mutates the whole workspace; select a branch in that
+control to exercise a feature branch.
+
+The caller passes a small set of configuration inputs, each carrying intent:
+
+- `paths` — set to `crates/`, the cargo workspace root. This bounds the
+  scheduled run's change detection to the Rust workspace, so a scheduled run
+  with nothing changed there is a cheap no-op.
+- `exclude-globs` — set to `crates/repovec-test-helpers/**`. That crate is a
+  dev-dependency fixture consumed only by other crates' tests, so mutating it
+  would only produce noise survivors.
+- `extra-args` — set to `--all-features --test-workspace=true`, so every
+  workspace member is mutated against the full workspace test run with all
+  features enabled, matching the CI test baseline. A mismatch here would
+  report feature-gated code as untested.
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test asserts only that the pin is a full
+commit SHA, not a particular value, so Dependabot bumps it automatically
+without any accompanying test edit; see
+[Section 2.1](#21-workflow-pins-and-dependabot) for the shape-only testing
+policy this follows.
+
+Because the caller is configuration rather than code, a contract test in
+[`tests/workflow_contracts/mutation_testing_test.py`](../tests/workflow_contracts/mutation_testing_test.py)
+pins the shape it must uphold, failing the pull request when the caller
+drifts — repointing the pin at a branch, widening the token scope, or
+dropping a configuration input — rather than letting the breakage surface
+only in a scheduled run. The module self-skips (`pytestmark =
+pytest.mark.skipif(...)`) when the workflow file is absent from the working
+copy, a defensive guard against collection from a stripped-down checkout.
+Run it locally with `make test-workflow-contracts`. The test validates:
+
+- the `uses:` reference targets `mutation-cargo.yml` pinned to a full commit
+  SHA;
+- the `with:` block carries exactly the expected `paths`, `exclude-globs`,
+  and `extra-args` above;
+- job permissions are least-privilege (`contents: read`, `id-token: write`)
+  and the workflow-level default token scope is empty;
+- `concurrency` serializes runs per ref without cancelling one in progress;
+  and
+- the triggers keep the daily schedule and a plain `workflow_dispatch` with
+  no legacy branch input.


### PR DESCRIPTION
## Summary

- Adds a `## Mutation-testing workflow contract tests` section to
  `docs/developers-guide.md`, documenting the caller workflow
  (`.github/workflows/mutation-testing.yml`), the reusable workflow it
  delegates to (`mutation-cargo.yml`), the real `with:` inputs (`paths`,
  `exclude-globs`, `extra-args`), and the contract test that pins the
  caller's shape.
- No such section existed previously, so this is a new top-level `##`
  heading rather than a subsection, per the placement convention used
  elsewhere in the guide.
- Adds a short forward cross-link from §2.1 ("Workflow pins and
  Dependabot", the existing shape-only contract-test policy) to the new
  section, since `docs/developers-guide.md` has no internal table of
  contents to update. The guide is already listed in `docs/contents.md`.

## Details reconciled against the repository

- Contract test style: **shape-only**. `tests/workflow_contracts/mutation_testing_test.py`
  asserts the `uses:` pin matches `USES_RE`
  (`...mutation-cargo\.yml@[0-9a-f]{40}$`) — it does not hard-code the
  current SHA, so Dependabot bumps it without any accompanying test
  edit.
- Workspace flag: the caller's `extra-args` is
  `--all-features --test-workspace=true`, documented verbatim.
- `exclude-globs` (`crates/repovec-test-helpers/**`) is documented as
  excluding a dev-dependency fixture crate whose survivors would be
  noise, matching the workflow's own comment.
- The `integration-tests/` Python harness is deliberately **not**
  mentioned as a mutation-testing concern, since it is not a mutation
  target for this caller.
- Local run command: `make test-workflow-contracts` (the target exists
  in the `Makefile` and was verified to pass locally).
- Roadmap/execplan tracking: `docs/roadmap.md` and `docs/execplans/*`
  have no items referencing mutation testing or this documentation
  work, so no roadmap update applies.

## Docs lint

Ran only the documentation gates (no Rust/Python test suite):

- `make markdownlint` — passed (0 errors after fixing two `-ize`/`-ise`
  spelling flags the new prose introduced: `summarizing`, `serializes`).
- `make nixie` — passed (no Mermaid diagrams added).

## Changed file

- `docs/developers-guide.md`
